### PR TITLE
Add exit command with CRT power-off shutdown

### DIFF
--- a/docs/plans/2026-03-01-exit-command-design.md
+++ b/docs/plans/2026-03-01-exit-command-design.md
@@ -1,0 +1,90 @@
+# Exit Command with CRT Power-Off Shutdown
+
+## Summary
+
+Add an `exit` command to the terminal that triggers a cinematic CRT monitor power-off animation, followed by a black screen with a "Press any key to restart" prompt that reboots into the boot splash.
+
+## Why not `window.close()`?
+
+Browsers block `window.close()` unless the tab was opened programmatically via `window.open()`. Direct navigation (URL bar, bookmarks, external links) makes `window.close()` silently fail. This is enforced by all major browsers on desktop and mobile. A visual shutdown sequence is the right alternative.
+
+## Command
+
+- **Trigger:** `exit` (no aliases)
+- **Appears in:** help output with icon and description: `exit — Terminate the current session`
+- **Added to:** suggestions list for tab-completion and ghost-text
+
+## Shutdown Sequence
+
+### Phase 1: Shutdown Messages (~2.5s)
+
+After Enter, the terminal prints staggered messages (~350ms each):
+
+```
+Broadcast message from root@dkoderinc (pts/0):
+The system is going down for halt NOW!
+Stopping all services...            [OK]
+Unmounting filesystems...           [OK]
+Flushing disk cache...              [OK]
+System halted.
+```
+
+These render as normal green terminal output lines.
+
+### Phase 2: CRT Collapse (~0.8s)
+
+The entire page (sidebar, terminal, copyright bar) animates:
+- Vertical scale compresses to 0, horizontal stays at 100%
+- Creates a thin bright horizontal line in the center
+- Brief white glow/brightness boost on the line (phosphor effect)
+
+### Phase 3: Dot Shrink + Fade (~0.6s)
+
+- Horizontal line shrinks to a small bright dot in center
+- Dot fades out to pure black
+
+### Phase 4: Black Screen + Restart Prompt
+
+- Pure black screen for ~2 seconds
+- Blinking green text appears centered: `Press any key to restart...`
+- Desktop: any keypress triggers restart
+- Mobile: tapping anywhere triggers restart
+
+### Restart
+
+- Re-triggers BootSplash animation
+- Returns to normal terminal with help displayed
+- Command history is cleared (fresh session)
+
+## Architecture
+
+### State Management
+
+New `shutdownPhase` state in `App.tsx`:
+- Values: `null | 'messages' | 'crt-off' | 'black' | 'restart-prompt'`
+- Lives in App.tsx because the CRT animation affects the entire page layout
+
+### Communication Flow
+
+1. `Terminal.handleCommand` recognizes `exit`, calls `onShutdown()` prop
+2. `App.tsx` receives callback, sets `shutdownPhase = 'messages'`
+3. App.tsx orchestrates phase transitions via `setTimeout` chains
+4. During `'crt-off'`: CSS class on root container triggers collapse animation
+5. During `'restart-prompt'`: overlay listens for keypress/touch
+6. On restart: all state resets, `showBootSplash = true`
+
+### CSS Animations (in index.css)
+
+- `crt-shutdown`: scales Y to 0 with brightness filter boost
+- `dot-shrink`: scales X to 0 and fades opacity
+
+### Mobile Support
+
+"Press any key to restart" screen listens for `touchstart` + `keydown`. Full-screen tap target, no virtual keyboard needed.
+
+## Files Changed
+
+- `src/components/Terminal/commands.tsx` — add `exit` command + suggestion entry
+- `src/components/Terminal/Terminal.tsx` — call `onShutdown` prop when `exit` entered
+- `src/App.tsx` — shutdown phase state machine, transitions, restart logic
+- `src/index.css` — CRT shutdown keyframe animations

--- a/docs/plans/2026-03-01-exit-command-plan.md
+++ b/docs/plans/2026-03-01-exit-command-plan.md
@@ -1,0 +1,427 @@
+# Exit Command with CRT Power-Off — Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Add an `exit` command that triggers a cinematic CRT power-off animation, black screen, and "Press any key to restart" reboot cycle.
+
+**Architecture:** The `exit` command is registered in the terminal's command system. When executed, it calls an `onShutdown` callback prop that bubbles up to `App.tsx`, which orchestrates a 4-phase shutdown sequence (messages → CRT collapse → dot fade → restart prompt) using a state machine and CSS animations. Restart re-triggers the existing `BootSplash` and resets all terminal state.
+
+**Tech Stack:** React 18, TypeScript, Tailwind CSS, CSS keyframe animations, existing Vite build.
+
+**Note:** This project has no test infrastructure — no test runner, no test files. Tasks skip TDD steps accordingly.
+
+---
+
+### Task 1: Add `exit` to command registry and suggestions
+
+**Files:**
+- Modify: `src/components/Terminal/commands.tsx`
+
+**Step 1: Add the `exit` suggestion entry**
+
+In `commands.tsx`, add a `LogOut` import from lucide-react and append an entry to the `suggestions` array:
+
+```tsx
+// Add to imports at line 2:
+import { Cpu, Mail, Sparkles, User, Info, FolderOpen, Clock, LogOut } from 'lucide-react';
+
+// Add to suggestions array after the 'clear' entry (line 13):
+{ command: 'exit', description: 'Terminate the current session', icon: <LogOut className="w-4 h-4 text-[#00FF41]" /> },
+```
+
+**Step 2: Add the `exit` command entry**
+
+The `exit` command doesn't need static output strings like other commands — it's handled specially in `Terminal.tsx`. But we still need an entry so the generic command lookup doesn't return "Command not found". Add to the `commands` record:
+
+```tsx
+// Add to the commands record (after 'projects' entry, around line 91):
+exit: [
+  'Shutting down...',
+],
+```
+
+**Step 3: Verify the dev server compiles**
+
+Run: `npm run dev` (check for TypeScript/compilation errors)
+Expected: Clean compile, no errors.
+
+**Step 4: Commit**
+
+```bash
+git add src/components/Terminal/commands.tsx
+git commit -m "feat: add exit command to registry and suggestions"
+```
+
+---
+
+### Task 2: Add CRT shutdown CSS animations
+
+**Files:**
+- Modify: `src/index.css`
+
+**Step 1: Add the keyframe animations and utility classes**
+
+Append the following to the end of `src/index.css`:
+
+```css
+/* CRT shutdown animation - Phase 2: vertical collapse to horizontal line */
+@keyframes crt-collapse {
+  0% {
+    transform: scaleY(1) scaleX(1);
+    filter: brightness(1);
+  }
+  60% {
+    transform: scaleY(0.005) scaleX(1);
+    filter: brightness(3);
+  }
+  100% {
+    transform: scaleY(0.005) scaleX(0);
+    filter: brightness(3);
+    opacity: 0;
+  }
+}
+
+.crt-shutdown {
+  animation: crt-collapse 1.4s cubic-bezier(0.2, 0, 0.8, 1) forwards;
+  transform-origin: center center;
+}
+
+/* Restart prompt blink */
+.restart-blink {
+  animation: blink 1s step-end infinite;
+}
+```
+
+This single `crt-collapse` animation handles both Phase 2 (vertical collapse, 0-60%) and Phase 3 (horizontal shrink + fade, 60-100%) in one smooth sequence. The `brightness(3)` creates the phosphor glow effect on the collapsing line. No need for a separate `dot-shrink` keyframe — combining them into one animation is simpler and produces a smoother result.
+
+The `restart-blink` class reuses the existing `blink` keyframe already defined in `index.css`.
+
+**Step 2: Verify the dev server compiles**
+
+Run: Check dev server for CSS errors.
+Expected: Clean compile.
+
+**Step 3: Commit**
+
+```bash
+git add src/index.css
+git commit -m "feat: add CRT shutdown CSS keyframe animations"
+```
+
+---
+
+### Task 3: Wire `exit` command in Terminal to call `onShutdown` prop
+
+**Files:**
+- Modify: `src/components/Terminal/Terminal.tsx`
+
+**Step 1: Accept `onShutdown` prop**
+
+Change the Terminal component signature to accept props:
+
+```tsx
+// Change line 29 from:
+const Terminal = forwardRef<TerminalHandle>((_, ref) => {
+
+// To:
+type TerminalProps = {
+  onShutdown?: () => void;
+};
+
+const Terminal = forwardRef<TerminalHandle, TerminalProps>(({ onShutdown }, ref) => {
+```
+
+**Step 2: Handle `exit` in `handleCommand`**
+
+Add an `exit` handler in `handleCommand` (after the `clear` block, around line 100). When `exit` is typed, we:
+1. Print the `$ exit` input line to terminal output
+2. Call `onShutdown()` — App.tsx takes over from here
+
+```tsx
+// Add after the 'clear' block (line 100) and before the 'uptime' block:
+if (trimmedCmd === 'exit') {
+  setTerminalOutput(prev => [
+    ...prev,
+    { content: `$ ${trimmedCmd}`, type: 'input', timestamp: getCurrentTime() },
+  ]);
+  setInputCommand('');
+  setAutoSuggestion(null);
+  onShutdown?.();
+  return;
+}
+```
+
+**Step 3: Verify the dev server compiles**
+
+Run: Check dev server.
+Expected: Clean compile. Typing `exit` in the terminal should print `$ exit` and then do nothing visible yet (since App.tsx doesn't handle the callback yet).
+
+**Step 4: Commit**
+
+```bash
+git add src/components/Terminal/Terminal.tsx
+git commit -m "feat: wire exit command to call onShutdown callback prop"
+```
+
+---
+
+### Task 4: Implement shutdown state machine and restart logic in App.tsx
+
+**Files:**
+- Modify: `src/App.tsx`
+
+This is the core task. App.tsx orchestrates the full shutdown sequence.
+
+**Step 1: Add shutdown state and message constants**
+
+```tsx
+// Add these imports at the top (update existing import line 1):
+import React, { useState, useCallback, useRef, useEffect } from 'react';
+
+// Add shutdown messages constant above the App component:
+const SHUTDOWN_MESSAGES = [
+  'Broadcast message from root@dkoderinc (pts/0):',
+  'The system is going down for halt NOW!',
+  'Stopping all services...            [OK]',
+  'Unmounting filesystems...           [OK]',
+  'Flushing disk cache...              [OK]',
+  'System halted.',
+];
+
+type ShutdownPhase = null | 'messages' | 'crt-off' | 'black' | 'restart-prompt';
+```
+
+**Step 2: Add state and shutdown handler inside the App component**
+
+```tsx
+// Inside the App component, after the existing state declarations:
+const [shutdownPhase, setShutdownPhase] = useState<ShutdownPhase>(null);
+const [shutdownLines, setShutdownLines] = useState(0);
+
+const handleShutdown = useCallback(() => {
+  setShutdownPhase('messages');
+  setShutdownLines(0);
+}, []);
+```
+
+**Step 3: Add the shutdown message phase effect**
+
+This effect prints shutdown messages one at a time (350ms apart), then transitions to the CRT-off phase:
+
+```tsx
+// Add useEffect for shutdown message sequencing:
+useEffect(() => {
+  if (shutdownPhase !== 'messages') return;
+
+  const timers: ReturnType<typeof setTimeout>[] = [];
+  SHUTDOWN_MESSAGES.forEach((_, i) => {
+    timers.push(setTimeout(() => setShutdownLines(i + 1), i * 350));
+  });
+  // After all messages shown, wait 500ms then start CRT collapse
+  timers.push(setTimeout(() => {
+    setShutdownPhase('crt-off');
+  }, SHUTDOWN_MESSAGES.length * 350 + 500));
+
+  return () => timers.forEach(clearTimeout);
+}, [shutdownPhase]);
+```
+
+**Step 4: Add the CRT-off → black → restart-prompt phase transitions**
+
+```tsx
+// Add useEffect for CRT animation phase transitions:
+useEffect(() => {
+  if (shutdownPhase !== 'crt-off') return;
+
+  // crt-collapse animation is 1.4s, then go to black
+  const timer = setTimeout(() => {
+    setShutdownPhase('black');
+  }, 1500);
+  return () => clearTimeout(timer);
+}, [shutdownPhase]);
+
+useEffect(() => {
+  if (shutdownPhase !== 'black') return;
+
+  // Stay black for 2s, then show restart prompt
+  const timer = setTimeout(() => {
+    setShutdownPhase('restart-prompt');
+  }, 2000);
+  return () => clearTimeout(timer);
+}, [shutdownPhase]);
+```
+
+**Step 5: Add the restart handler**
+
+```tsx
+// Add restart handler and its effect:
+const handleRestart = useCallback(() => {
+  setShutdownPhase(null);
+  setShutdownLines(0);
+  setShowBootSplash(true);
+}, []);
+
+useEffect(() => {
+  if (shutdownPhase !== 'restart-prompt') return;
+
+  const onKey = () => handleRestart();
+  const onTouch = () => handleRestart();
+
+  window.addEventListener('keydown', onKey);
+  window.addEventListener('touchstart', onTouch);
+  return () => {
+    window.removeEventListener('keydown', onKey);
+    window.removeEventListener('touchstart', onTouch);
+  };
+}, [shutdownPhase, handleRestart]);
+```
+
+**Step 6: Update the JSX return**
+
+Replace the entire return block. Key changes:
+- Pass `onShutdown={handleShutdown}` to `<Terminal>`
+- Add `crt-shutdown` class to the main content wrapper when `shutdownPhase === 'crt-off'`
+- Render shutdown messages overlay during `'messages'` phase
+- Render black screen during `'black'` phase
+- Render restart prompt during `'restart-prompt'` phase
+- Use a `key` prop on `Terminal` that changes on restart to force a fresh mount (clearing all internal state — command history, output, etc.)
+
+```tsx
+// Add a restart counter to force Terminal remount:
+const [sessionKey, setSessionKey] = useState(0);
+
+// Update handleRestart to increment the key:
+const handleRestart = useCallback(() => {
+  setShutdownPhase(null);
+  setShutdownLines(0);
+  setSessionKey(k => k + 1);
+  setShowBootSplash(true);
+}, []);
+```
+
+The full JSX return:
+
+```tsx
+return (
+  <div className="flex flex-col overflow-hidden" style={{ background: '#000', height: '100dvh' }}>
+    {showBootSplash && <BootSplash onComplete={handleBootComplete} />}
+
+    {/* Shutdown messages overlay */}
+    {shutdownPhase === 'messages' && (
+      <div
+        className="fixed inset-0 z-[9000] flex flex-col justify-center items-start p-8 md:p-16"
+        style={{ background: '#000' }}
+      >
+        {SHUTDOWN_MESSAGES.slice(0, shutdownLines).map((line, i) => (
+          <p key={i} className="font-mono text-sm mb-1" style={{ color: '#00FF41' }}>
+            {line}
+          </p>
+        ))}
+      </div>
+    )}
+
+    {/* Black screen + restart prompt */}
+    {(shutdownPhase === 'black' || shutdownPhase === 'restart-prompt') && (
+      <div
+        className="fixed inset-0 z-[9000] flex items-center justify-center"
+        style={{ background: '#000' }}
+      >
+        {shutdownPhase === 'restart-prompt' && (
+          <p className="font-mono text-sm restart-blink" style={{ color: '#00FF41' }}>
+            Press any key to restart...
+          </p>
+        )}
+      </div>
+    )}
+
+    <div
+      className={`flex flex-col flex-1 overflow-hidden ${shutdownPhase === 'crt-off' ? 'crt-shutdown' : ''}`}
+      style={{
+        opacity: showBootSplash ? 0 : 1,
+        transition: shutdownPhase ? undefined : 'opacity 0.3s',
+      }}
+    >
+      <div className="flex flex-col md:flex-row flex-1 overflow-hidden">
+        <Sidebar />
+        <main className="flex flex-1 overflow-hidden p-3 md:p-4">
+          <TerminalWindow>
+            <Terminal key={sessionKey} ref={terminalRef} onShutdown={handleShutdown} />
+          </TerminalWindow>
+        </main>
+      </div>
+      {/* Mobile virtual keyboard shortcuts */}
+      <div
+        className="flex md:hidden shrink-0 gap-2 p-2 border-t"
+        style={{ borderColor: '#333' }}
+      >
+        {mobileKeys.map(({ label, action }) => (
+          <button
+            key={label}
+            className="flex-1 py-2 font-mono text-sm rounded"
+            style={{ background: '#111', color: '#00FF41', border: '1px solid #333' }}
+            data-mobile-action={action}
+            onClick={() => terminalRef.current?.handleMobileAction(action)}
+          >
+            {label}
+          </button>
+        ))}
+      </div>
+      {/* Copyright */}
+      <div
+        className="flex justify-center shrink-0 py-2 font-mono text-xs border-t"
+        style={{ color: '#888', borderColor: '#333', paddingBottom: 'max(0.5rem, env(safe-area-inset-bottom))' }}
+      >
+        <span style={{ color: '#888' }}>$ cat /etc/copyright&nbsp;&nbsp;</span>
+        <span style={{ color: '#00FF41' }}>&copy; {new Date().getFullYear()} DKoder Inc.</span>
+      </div>
+    </div>
+  </div>
+);
+```
+
+**Step 7: Verify the full flow in the browser**
+
+Run: Open dev server in browser. Type `exit`. Verify:
+1. Shutdown messages appear one at a time (~350ms each)
+2. After messages, the entire page collapses vertically (CRT effect)
+3. Screen goes black for ~2 seconds
+4. "Press any key to restart..." appears blinking
+5. Pressing any key (or tapping on mobile) triggers the boot splash
+6. After boot, terminal is fresh — no command history, help is displayed
+
+**Step 8: Commit**
+
+```bash
+git add src/App.tsx
+git commit -m "feat: implement shutdown state machine with CRT power-off and restart"
+```
+
+---
+
+### Task 5: Visual polish and edge case handling
+
+**Files:**
+- Modify: `src/App.tsx` (if needed)
+- Modify: `src/index.css` (if needed)
+
+**Step 1: Test edge cases**
+
+Verify in the browser:
+- Typing `exit` during boot splash doesn't trigger shutdown
+- Typing `exit` multiple times rapidly doesn't stack animations
+- Mobile: tapping the screen during restart prompt works
+- The CRT scanline overlay (`body::before`) doesn't interfere with the shutdown animation (it's at `z-index: 9999`, shutdown overlays are at `z-index: 9000` — the scanlines should still appear on top, which is correct)
+- After restart, the terminal input is focused and functional
+
+**Step 2: Fix any issues found**
+
+Address anything that doesn't work as expected.
+
+**Step 3: Final commit**
+
+```bash
+git add -A
+git commit -m "fix: polish exit command edge cases"
+```
+
+Only create this commit if changes were made.

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useCallback, useRef } from 'react';
+import React, { useState, useCallback, useRef, useEffect } from 'react';
 import BootSplash from './components/BootSplash';
 import Sidebar from './components/Sidebar';
 import TerminalWindow from './components/TerminalWindow';
@@ -11,23 +11,122 @@ const mobileKeys = [
   { label: 'Enter', action: 'enter' as const },
 ];
 
+const SHUTDOWN_MESSAGES = [
+  'Broadcast message from root@dkoderinc (pts/0):',
+  'The system is going down for halt NOW!',
+  'Stopping all services...            [OK]',
+  'Unmounting filesystems...           [OK]',
+  'Flushing disk cache...              [OK]',
+  'System halted.',
+];
+
+type ShutdownPhase = null | 'messages' | 'crt-off' | 'black' | 'restart-prompt';
+
 const App: React.FC = () => {
   const [showBootSplash, setShowBootSplash] = useState(true);
   const handleBootComplete = useCallback(() => setShowBootSplash(false), []);
   const terminalRef = useRef<TerminalHandle>(null);
 
+  const [shutdownPhase, setShutdownPhase] = useState<ShutdownPhase>(null);
+  const [shutdownLines, setShutdownLines] = useState(0);
+  const [sessionKey, setSessionKey] = useState(0);
+
+  const handleShutdown = useCallback(() => {
+    setShutdownPhase('messages');
+    setShutdownLines(0);
+  }, []);
+
+  const handleRestart = useCallback(() => {
+    setShutdownPhase(null);
+    setShutdownLines(0);
+    setSessionKey(k => k + 1);
+    setShowBootSplash(true);
+  }, []);
+
+  // Shutdown messages phase - show lines one at a time
+  useEffect(() => {
+    if (shutdownPhase !== 'messages') return;
+    const timers: ReturnType<typeof setTimeout>[] = [];
+    SHUTDOWN_MESSAGES.forEach((_, i) => {
+      timers.push(setTimeout(() => setShutdownLines(i + 1), i * 350));
+    });
+    timers.push(setTimeout(() => {
+      setShutdownPhase('crt-off');
+    }, SHUTDOWN_MESSAGES.length * 350 + 500));
+    return () => timers.forEach(clearTimeout);
+  }, [shutdownPhase]);
+
+  // CRT collapse phase - wait for animation to finish
+  useEffect(() => {
+    if (shutdownPhase !== 'crt-off') return;
+    const timer = setTimeout(() => setShutdownPhase('black'), 1500);
+    return () => clearTimeout(timer);
+  }, [shutdownPhase]);
+
+  // Black screen phase - pause then show restart prompt
+  useEffect(() => {
+    if (shutdownPhase !== 'black') return;
+    const timer = setTimeout(() => setShutdownPhase('restart-prompt'), 2000);
+    return () => clearTimeout(timer);
+  }, [shutdownPhase]);
+
+  // Restart prompt phase - listen for any key/touch
+  useEffect(() => {
+    if (shutdownPhase !== 'restart-prompt') return;
+    const onKey = () => handleRestart();
+    const onTouch = () => handleRestart();
+    window.addEventListener('keydown', onKey);
+    window.addEventListener('touchstart', onTouch);
+    return () => {
+      window.removeEventListener('keydown', onKey);
+      window.removeEventListener('touchstart', onTouch);
+    };
+  }, [shutdownPhase, handleRestart]);
+
   return (
     <div className="flex flex-col overflow-hidden" style={{ background: '#000', height: '100dvh' }}>
       {showBootSplash && <BootSplash onComplete={handleBootComplete} />}
+
+      {/* Shutdown messages overlay */}
+      {shutdownPhase === 'messages' && (
+        <div
+          className="fixed inset-0 z-[9000] flex flex-col justify-center items-start p-8 md:p-16"
+          style={{ background: '#000' }}
+        >
+          {SHUTDOWN_MESSAGES.slice(0, shutdownLines).map((line, i) => (
+            <p key={i} className="font-mono text-sm mb-1" style={{ color: '#00FF41' }}>
+              {line}
+            </p>
+          ))}
+        </div>
+      )}
+
+      {/* Black screen + restart prompt */}
+      {(shutdownPhase === 'black' || shutdownPhase === 'restart-prompt') && (
+        <div
+          className="fixed inset-0 z-[9000] flex items-center justify-center"
+          style={{ background: '#000' }}
+        >
+          {shutdownPhase === 'restart-prompt' && (
+            <p className="font-mono text-sm restart-blink" style={{ color: '#00FF41' }}>
+              Press any key to restart...
+            </p>
+          )}
+        </div>
+      )}
+
       <div
-        className="flex flex-col flex-1 overflow-hidden"
-        style={{ opacity: showBootSplash ? 0 : 1, transition: 'opacity 0.3s' }}
+        className={`flex flex-col flex-1 overflow-hidden ${shutdownPhase === 'crt-off' ? 'crt-shutdown' : ''}`}
+        style={{
+          opacity: showBootSplash ? 0 : 1,
+          transition: shutdownPhase ? undefined : 'opacity 0.3s',
+        }}
       >
         <div className="flex flex-col md:flex-row flex-1 overflow-hidden">
           <Sidebar />
           <main className="flex flex-1 overflow-hidden p-3 md:p-4">
             <TerminalWindow>
-              <Terminal ref={terminalRef} />
+              <Terminal key={sessionKey} ref={terminalRef} onShutdown={handleShutdown} />
             </TerminalWindow>
           </main>
         </div>

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -45,50 +45,41 @@ const App: React.FC = () => {
     setShowBootSplash(true);
   }, []);
 
-  // Shutdown messages phase - show lines one at a time
+  // Shutdown sequence state machine
   useEffect(() => {
-    if (shutdownPhase !== 'messages') return;
+    if (!shutdownPhase) return;
+
     const timers: ReturnType<typeof setTimeout>[] = [];
-    SHUTDOWN_MESSAGES.forEach((_, i) => {
-      timers.push(setTimeout(() => setShutdownLines(i + 1), i * 350));
-    });
-    timers.push(setTimeout(() => {
-      setShutdownPhase('crt-off');
-    }, SHUTDOWN_MESSAGES.length * 350 + 500));
+
+    switch (shutdownPhase) {
+      case 'messages':
+        SHUTDOWN_MESSAGES.forEach((_, i) => {
+          timers.push(setTimeout(() => setShutdownLines(i + 1), i * 350));
+        });
+        timers.push(setTimeout(() => setShutdownPhase('crt-off'), SHUTDOWN_MESSAGES.length * 350 + 500));
+        break;
+
+      case 'crt-off':
+        timers.push(setTimeout(() => setShutdownPhase('black'), 1500));
+        break;
+
+      case 'black':
+        timers.push(setTimeout(() => setShutdownPhase('restart-prompt'), 1000));
+        break;
+
+      case 'restart-prompt': {
+        const onKey = (e: KeyboardEvent) => { e.preventDefault(); handleRestart(); };
+        const onTouch = (e: TouchEvent) => { e.preventDefault(); handleRestart(); };
+        window.addEventListener('keydown', onKey);
+        window.addEventListener('touchstart', onTouch);
+        return () => {
+          window.removeEventListener('keydown', onKey);
+          window.removeEventListener('touchstart', onTouch);
+        };
+      }
+    }
+
     return () => timers.forEach(clearTimeout);
-  }, [shutdownPhase]);
-
-  // CRT collapse phase - wait for animation to finish
-  useEffect(() => {
-    if (shutdownPhase !== 'crt-off') return;
-    const timer = setTimeout(() => setShutdownPhase('black'), 1500);
-    return () => clearTimeout(timer);
-  }, [shutdownPhase]);
-
-  // Black screen phase - pause then show restart prompt
-  useEffect(() => {
-    if (shutdownPhase !== 'black') return;
-    const timer = setTimeout(() => setShutdownPhase('restart-prompt'), 1000);
-    return () => clearTimeout(timer);
-  }, [shutdownPhase]);
-
-  // Restart prompt phase - listen for any key/touch
-  useEffect(() => {
-    if (shutdownPhase !== 'restart-prompt') return;
-    const onKey = (e: KeyboardEvent) => {
-      e.preventDefault();
-      handleRestart();
-    };
-    const onTouch = (e: TouchEvent) => {
-      e.preventDefault();
-      handleRestart();
-    };
-    window.addEventListener('keydown', onKey);
-    window.addEventListener('touchstart', onTouch);
-    return () => {
-      window.removeEventListener('keydown', onKey);
-      window.removeEventListener('touchstart', onTouch);
-    };
   }, [shutdownPhase, handleRestart]);
 
   return (

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -120,7 +120,8 @@ const App: React.FC = () => {
               <p className="mb-1" style={{ color: '#888' }}>Reboot scheduled.</p>
               <p className="mb-4" style={{ color: '#888' }}>Waiting for user input...</p>
               <p style={{ color: '#00FF41' }}>
-                Press any key to continue... <span className="animate-blink">&#x2588;</span>
+                <span className="hidden md:inline">Press any key to continue... <span className="animate-blink">&#x2588;</span></span>
+                <span className="md:hidden">Tap to continue... <span className="animate-blink">&#x2588;</span></span>
               </p>
             </div>
           )}

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -68,7 +68,7 @@ const App: React.FC = () => {
   // Black screen phase - pause then show restart prompt
   useEffect(() => {
     if (shutdownPhase !== 'black') return;
-    const timer = setTimeout(() => setShutdownPhase('restart-prompt'), 2000);
+    const timer = setTimeout(() => setShutdownPhase('restart-prompt'), 1000);
     return () => clearTimeout(timer);
   }, [shutdownPhase]);
 
@@ -116,9 +116,13 @@ const App: React.FC = () => {
           style={{ background: '#000' }}
         >
           {shutdownPhase === 'restart-prompt' && (
-            <p className="font-mono text-sm restart-blink" style={{ color: '#00FF41' }}>
-              Press any key to restart...
-            </p>
+            <div className="text-center font-mono text-sm phosphor-glow">
+              <p className="mb-1" style={{ color: '#888' }}>Reboot scheduled.</p>
+              <p className="mb-4" style={{ color: '#888' }}>Waiting for user input...</p>
+              <p style={{ color: '#00FF41' }}>
+                Press any key to continue... <span className="animate-blink">&#x2588;</span>
+              </p>
+            </div>
           )}
         </div>
       )}

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -3,6 +3,7 @@ import BootSplash from './components/BootSplash';
 import Sidebar from './components/Sidebar';
 import TerminalWindow from './components/TerminalWindow';
 import Terminal, { TerminalHandle } from './components/Terminal';
+import { resetPageLoadTime } from './constants';
 
 const mobileKeys = [
   { label: 'Tab', action: 'tab' as const },
@@ -37,6 +38,7 @@ const App: React.FC = () => {
   }, []);
 
   const handleRestart = useCallback(() => {
+    resetPageLoadTime();
     setShutdownPhase(null);
     setShutdownLines(0);
     setSessionKey(k => k + 1);
@@ -73,8 +75,14 @@ const App: React.FC = () => {
   // Restart prompt phase - listen for any key/touch
   useEffect(() => {
     if (shutdownPhase !== 'restart-prompt') return;
-    const onKey = () => handleRestart();
-    const onTouch = () => handleRestart();
+    const onKey = (e: KeyboardEvent) => {
+      e.preventDefault();
+      handleRestart();
+    };
+    const onTouch = (e: TouchEvent) => {
+      e.preventDefault();
+      handleRestart();
+    };
     window.addEventListener('keydown', onKey);
     window.addEventListener('touchstart', onTouch);
     return () => {
@@ -123,7 +131,7 @@ const App: React.FC = () => {
         }}
       >
         <div className="flex flex-col md:flex-row flex-1 overflow-hidden">
-          <Sidebar />
+          <Sidebar key={sessionKey} />
           <main className="flex flex-1 overflow-hidden p-3 md:p-4">
             <TerminalWindow>
               <Terminal key={sessionKey} ref={terminalRef} onShutdown={handleShutdown} />

--- a/src/components/Terminal/Terminal.tsx
+++ b/src/components/Terminal/Terminal.tsx
@@ -26,7 +26,11 @@ const useIsMobile = () => {
   return isMobile;
 };
 
-const Terminal = forwardRef<TerminalHandle>((_, ref) => {
+type TerminalProps = {
+  onShutdown?: () => void;
+};
+
+const Terminal = forwardRef<TerminalHandle, TerminalProps>(({ onShutdown }, ref) => {
   const isMobile = useIsMobile();
   const [terminalOutput, setTerminalOutput] = useState<TerminalLine[]>([]);
   const [inputCommand, setInputCommand] = useState('');
@@ -96,6 +100,17 @@ const Terminal = forwardRef<TerminalHandle>((_, ref) => {
       setTerminalOutput(displayHelp());
       setInputCommand('');
       setAutoSuggestion(null);
+      return;
+    }
+
+    if (trimmedCmd === 'exit') {
+      setTerminalOutput(prev => [
+        ...prev,
+        { content: `$ ${trimmedCmd}`, type: 'input', timestamp: getCurrentTime() },
+      ]);
+      setInputCommand('');
+      setAutoSuggestion(null);
+      onShutdown?.();
       return;
     }
 

--- a/src/components/Terminal/commands.tsx
+++ b/src/components/Terminal/commands.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Cpu, Mail, Sparkles, User, Info, FolderOpen, Clock } from 'lucide-react';
+import { Cpu, Mail, Sparkles, User, Info, FolderOpen, Clock, LogOut } from 'lucide-react';
 import { CommandSuggestion } from './types';
 
 export const suggestions: CommandSuggestion[] = [
@@ -11,6 +11,7 @@ export const suggestions: CommandSuggestion[] = [
   { command: 'uptime', description: 'Session uptime', icon: <Clock className="w-4 h-4 text-[#00FF41]" /> },
   { command: 'uname -a', description: 'System info', icon: <Info className="w-4 h-4 text-[#00FF41]" /> },
   { command: 'clear', description: 'Clear terminal screen', icon: <Sparkles className="w-4 h-4 text-[#00FF41]" /> },
+  { command: 'exit', description: 'Terminate the current session', icon: <LogOut className="w-4 h-4 text-[#00FF41]" /> },
 ];
 
 export const commands: Record<string, string[]> = {
@@ -88,5 +89,8 @@ export const commands: Record<string, string[]> = {
     '',
     '  See pinned repositories and contributions at:',
     '  <a href="https://github.com/dkoval" target="_blank" rel="noopener noreferrer" class="text-[#00FF41] hover:underline">https://github.com/dkoval</a>',
+  ],
+  exit: [
+    'Shutting down...',
   ],
 };

--- a/src/components/Terminal/commands.tsx
+++ b/src/components/Terminal/commands.tsx
@@ -90,7 +90,4 @@ export const commands: Record<string, string[]> = {
     '  See pinned repositories and contributions at:',
     '  <a href="https://github.com/dkoval" target="_blank" rel="noopener noreferrer" class="text-[#00FF41] hover:underline">https://github.com/dkoval</a>',
   ],
-  exit: [
-    'Shutting down...',
-  ],
 };

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -1,4 +1,8 @@
-export const PAGE_LOAD_TIME = Date.now();
+export let PAGE_LOAD_TIME = Date.now();
+
+export const resetPageLoadTime = () => {
+  PAGE_LOAD_TIME = Date.now();
+};
 
 export const formatUptime = (s: number): string => {
   const d = Math.floor(s / 86400);

--- a/src/index.css
+++ b/src/index.css
@@ -105,3 +105,30 @@ body {
 .terminal-scroll::-webkit-scrollbar-thumb:hover {
   background: #00FF41;
 }
+
+/* CRT shutdown animation - vertical collapse to horizontal line, then shrink to dot */
+@keyframes crt-collapse {
+  0% {
+    transform: scaleY(1) scaleX(1);
+    filter: brightness(1);
+  }
+  60% {
+    transform: scaleY(0.005) scaleX(1);
+    filter: brightness(3);
+  }
+  100% {
+    transform: scaleY(0.005) scaleX(0);
+    filter: brightness(3);
+    opacity: 0;
+  }
+}
+
+.crt-shutdown {
+  animation: crt-collapse 1.4s cubic-bezier(0.2, 0, 0.8, 1) forwards;
+  transform-origin: center center;
+}
+
+/* Restart prompt blink */
+.restart-blink {
+  animation: blink 1s step-end infinite;
+}

--- a/src/index.css
+++ b/src/index.css
@@ -128,7 +128,7 @@ body {
   transform-origin: center center;
 }
 
-/* Restart prompt blink */
-.restart-blink {
-  animation: blink 1s step-end infinite;
+/* Phosphor glow on restart prompt */
+.phosphor-glow {
+  text-shadow: 0 0 8px rgba(0, 255, 65, 0.4), 0 0 20px rgba(0, 255, 65, 0.15);
 }


### PR DESCRIPTION
## Summary
- Add `exit` command to the terminal that triggers a cinematic CRT monitor power-off animation
- 4-phase shutdown sequence: UNIX halt messages → CRT vertical collapse with phosphor glow → black screen → BIOS-style "Press any key to continue..." restart prompt
- Restart reboots into boot splash with fresh terminal state (command history, uptime all reset)
- Mobile-friendly: shows "Tap to continue..." and responds to touch events

## Test plan
- [ ] Type `exit` — verify shutdown messages appear one at a time
- [ ] Verify CRT collapse animation plays (vertical squeeze → horizontal shrink → fade)
- [ ] Verify black screen appears, then restart prompt with blinking cursor
- [ ] Press any key — verify boot splash plays and terminal resets (fresh help, empty history)
- [ ] Verify sidebar uptime resets to 0 after restart
- [ ] Verify input placeholder shows correctly after restart
- [ ] Test on mobile viewport — verify "Tap to continue..." text and touch-to-restart
- [ ] Verify `exit` appears in help output and tab-completion suggestions

🤖 Generated with [Claude Code](https://claude.com/claude-code)