### PR TITLE
Add typing effect to restart prompt

### DIFF
--- a/docs/plans/2026-03-01-restart-typing-effect-design.md
+++ b/docs/plans/2026-03-01-restart-typing-effect-design.md
@@ -1,0 +1,48 @@
+# Design: Typing Effect for Restart Prompt
+
+## Summary
+
+Add character-by-character typing animation to the restart prompt screen (the 3 lines shown after CRT shutdown). Retains UNIX terminal aesthetic.
+
+## Scope
+
+Only the `restart-prompt` phase. The 6 shutdown messages (before CRT-off) remain unchanged.
+
+## Behavior
+
+1. `shutdownPhase` transitions to `'restart-prompt'`
+2. Line 1 ("Reboot scheduled.") types at ~50ms/char
+3. Pause ~400ms
+4. Line 2 ("Waiting for user input...") types at ~50ms/char
+5. Pause ~400ms
+6. Line 3 ("Press any key to continue..." or "Tap to continue...") types at ~50ms/char
+7. Cursor switches from solid to blinking after all lines finish
+
+## Cursor
+
+- Solid block (`█`) follows typing position during animation
+- Switches to `.animate-blink` after all lines complete
+
+## User Input
+
+- `keydown`/`touchstart` listener activates only after typing finishes
+- Prevents accidental restart mid-animation
+
+## State
+
+Added to App.tsx (no new files):
+
+- `typingLine` (0-2): current line index
+- `typingChar`: revealed character count for current line
+- `typingDone`: boolean, enables input + blinking cursor
+
+## Styling
+
+- Lines 1-2: gray (#888)
+- Line 3: green (#00FF41)
+- Classes: `phosphor-glow`, `font-mono text-sm`, `text-center`
+- Responsive: desktop shows "Press any key", mobile shows "Tap to continue"
+
+## Approach
+
+React state-driven with `setTimeout` (Approach A). Matches existing shutdown message pattern. No new components or dependencies.

--- a/docs/plans/2026-03-01-restart-typing-effect.md
+++ b/docs/plans/2026-03-01-restart-typing-effect.md
@@ -1,0 +1,255 @@
+# Restart Prompt Typing Effect — Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Add character-by-character typing animation to the 3-line restart prompt screen.
+
+**Architecture:** A single `useEffect` in App.tsx drives a typing sequence through 3 lines using `setTimeout`. State tracks which line and character position we're at. The keydown/touchstart listener only attaches after typing completes.
+
+**Tech Stack:** React 18 state + setTimeout (no new dependencies)
+
+**Design doc:** `docs/plans/2026-03-01-restart-typing-effect-design.md`
+
+---
+
+### Task 1: Add restart prompt line constants
+
+**Files:**
+- Modify: `src/App.tsx:15-22` (add new constant after SHUTDOWN_MESSAGES)
+
+**Step 1: Add the RESTART_LINES constant**
+
+Add this constant right after `SHUTDOWN_MESSAGES` (after line 22):
+
+```typescript
+const RESTART_LINES = [
+  { text: 'Reboot scheduled.', color: '#888' },
+  { text: 'Waiting for user input...', color: '#888' },
+];
+
+const RESTART_FINAL_DESKTOP = 'Press any key to continue... ';
+const RESTART_FINAL_MOBILE = 'Tap to continue... ';
+```
+
+Note: Line 3 is separate because it has special color (#00FF41) and responsive variants.
+
+**Step 2: Commit**
+
+```bash
+git add src/App.tsx
+git commit -m "feat: add restart prompt line constants"
+```
+
+---
+
+### Task 2: Add typing state and useEffect
+
+**Files:**
+- Modify: `src/App.tsx` (add state vars after line 33, add useEffect)
+
+**Step 1: Add typing state**
+
+After `const [sessionKey, setSessionKey] = useState(0);` (line 33), add:
+
+```typescript
+const [typingLine, setTypingLine] = useState(0);
+const [typingChar, setTypingChar] = useState(0);
+const [typingDone, setTypingDone] = useState(false);
+```
+
+**Step 2: Reset typing state in handleRestart**
+
+In `handleRestart` (around line 40-46), add resets before `setShutdownPhase(null)`:
+
+```typescript
+const handleRestart = useCallback(() => {
+  resetPageLoadTime();
+  setTypingLine(0);
+  setTypingChar(0);
+  setTypingDone(false);
+  setShutdownPhase(null);
+  setShutdownLines(0);
+  setSessionKey(k => k + 1);
+  setShowBootSplash(true);
+}, []);
+```
+
+**Step 3: Add typing useEffect**
+
+Add a new `useEffect` after the existing shutdown sequence useEffect (after line 83). This drives the character-by-character typing:
+
+```typescript
+// Typing animation for restart prompt
+useEffect(() => {
+  if (shutdownPhase !== 'restart-prompt' || typingDone) return;
+
+  // Determine the full text of the current line
+  const allLines = [
+    RESTART_LINES[0].text,
+    RESTART_LINES[1].text,
+    // Use desktop text for timing (mobile is shorter, but we type at same pace)
+    RESTART_FINAL_DESKTOP,
+  ];
+
+  const currentText = allLines[typingLine];
+  if (!currentText) return;
+
+  if (typingChar < currentText.length) {
+    // Type next character
+    const timer = setTimeout(() => setTypingChar(c => c + 1), 50);
+    return () => clearTimeout(timer);
+  }
+
+  // Current line finished
+  if (typingLine < allLines.length - 1) {
+    // Pause, then move to next line
+    const timer = setTimeout(() => {
+      setTypingLine(l => l + 1);
+      setTypingChar(0);
+    }, 400);
+    return () => clearTimeout(timer);
+  }
+
+  // All lines done
+  setTypingDone(true);
+}, [shutdownPhase, typingLine, typingChar, typingDone]);
+```
+
+**Step 4: Commit**
+
+```bash
+git add src/App.tsx
+git commit -m "feat: add typing state and animation useEffect"
+```
+
+---
+
+### Task 3: Gate keydown/touchstart listener on typingDone
+
+**Files:**
+- Modify: `src/App.tsx` (the `restart-prompt` case in the shutdown useEffect, around line 70-79)
+
+**Step 1: Update the restart-prompt case**
+
+Replace the existing `case 'restart-prompt'` block with:
+
+```typescript
+case 'restart-prompt':
+  // Listener is attached by a separate effect that depends on typingDone
+  break;
+```
+
+**Step 2: Add a new useEffect for the input listener**
+
+Add after the typing useEffect:
+
+```typescript
+// Attach restart listener only after typing completes
+useEffect(() => {
+  if (shutdownPhase !== 'restart-prompt' || !typingDone) return;
+
+  const onKey = (e: KeyboardEvent) => { e.preventDefault(); handleRestart(); };
+  const onTouch = (e: TouchEvent) => { e.preventDefault(); handleRestart(); };
+  window.addEventListener('keydown', onKey);
+  window.addEventListener('touchstart', onTouch);
+  return () => {
+    window.removeEventListener('keydown', onKey);
+    window.removeEventListener('touchstart', onTouch);
+  };
+}, [shutdownPhase, typingDone, handleRestart]);
+```
+
+**Step 3: Commit**
+
+```bash
+git add src/App.tsx
+git commit -m "feat: gate restart input on typing completion"
+```
+
+---
+
+### Task 4: Update JSX to render typed characters with cursor
+
+**Files:**
+- Modify: `src/App.tsx` (the restart-prompt JSX, around lines 109-117)
+
+**Step 1: Replace the restart prompt JSX**
+
+Replace the current `{shutdownPhase === 'restart-prompt' && (...)}` block (lines 109-117) with:
+
+```tsx
+{shutdownPhase === 'restart-prompt' && (
+  <div className="text-center font-mono text-sm phosphor-glow">
+    {/* Completed lines */}
+    {RESTART_LINES.slice(0, typingLine).map((line, i) => (
+      <p key={i} className={i === 0 ? 'mb-1' : 'mb-4'} style={{ color: line.color }}>
+        {line.text}
+      </p>
+    ))}
+
+    {/* Currently typing line (lines 0-1: gray) */}
+    {typingLine < RESTART_LINES.length && (
+      <p className={typingLine === 0 ? 'mb-1' : 'mb-4'} style={{ color: RESTART_LINES[typingLine].color }}>
+        {RESTART_LINES[typingLine].text.slice(0, typingChar)}
+        <span className={typingDone ? 'animate-blink' : ''}>&#x2588;</span>
+      </p>
+    )}
+
+    {/* Line 3: green, responsive, shows after first 2 lines done */}
+    {typingLine >= RESTART_LINES.length && (
+      <p style={{ color: '#00FF41' }}>
+        <span className="hidden md:inline">
+          {RESTART_FINAL_DESKTOP.slice(0, typingChar)}
+        </span>
+        <span className="md:hidden">
+          {RESTART_FINAL_MOBILE.slice(0, Math.min(typingChar, RESTART_FINAL_MOBILE.length))}
+        </span>
+        <span className={typingDone ? 'animate-blink' : ''}>&#x2588;</span>
+      </p>
+    )}
+  </div>
+)}
+```
+
+**Step 2: Commit**
+
+```bash
+git add src/App.tsx
+git commit -m "feat: render typed characters with cursor on restart prompt"
+```
+
+---
+
+### Task 5: Manual verification
+
+**Step 1: Start dev server**
+
+```bash
+npm run dev
+```
+
+**Step 2: Verify the typing effect**
+
+1. Open the site in browser
+2. Type `exit` in the terminal and press Enter
+3. Watch the shutdown messages (should be unchanged — line-by-line reveal)
+4. After CRT-off and black screen, observe:
+   - "Reboot scheduled." types out character by character with solid cursor
+   - ~400ms pause
+   - "Waiting for user input..." types out with solid cursor
+   - ~400ms pause
+   - "Press any key to continue..." types out, then cursor starts blinking
+5. Press any key — should restart (boot splash → terminal)
+6. On mobile viewport: verify "Tap to continue..." appears instead
+
+**Step 3: Verify no input during typing**
+
+- During the typing animation, press keys — nothing should happen
+- Only after the blinking cursor appears should keypress trigger restart
+
+**Step 4: Commit any fixes if needed, then final commit**
+
+```bash
+git add -A
+git commit -m "feat: restart prompt typing effect complete"
+```

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -157,12 +157,33 @@ const App: React.FC = () => {
         >
           {shutdownPhase === 'restart-prompt' && (
             <div className="text-center font-mono text-sm phosphor-glow">
-              <p className="mb-1" style={{ color: '#888' }}>Reboot scheduled.</p>
-              <p className="mb-4" style={{ color: '#888' }}>Waiting for user input...</p>
-              <p style={{ color: '#00FF41' }}>
-                <span className="hidden md:inline">Press any key to continue... <span className="animate-blink">&#x2588;</span></span>
-                <span className="md:hidden">Tap to continue... <span className="animate-blink">&#x2588;</span></span>
-              </p>
+              {/* Completed lines */}
+              {RESTART_LINES.slice(0, typingLine).map((line, i) => (
+                <p key={i} className={i === 0 ? 'mb-1' : 'mb-4'} style={{ color: line.color }}>
+                  {line.text}
+                </p>
+              ))}
+
+              {/* Currently typing line (lines 0-1: gray) */}
+              {typingLine < RESTART_LINES.length && (
+                <p className={typingLine === 0 ? 'mb-1' : 'mb-4'} style={{ color: RESTART_LINES[typingLine].color }}>
+                  {RESTART_LINES[typingLine].text.slice(0, typingChar)}
+                  <span className={typingDone ? 'animate-blink' : ''}>&#x2588;</span>
+                </p>
+              )}
+
+              {/* Line 3: green, responsive, shows after first 2 lines done */}
+              {typingLine >= RESTART_LINES.length && (
+                <p style={{ color: '#00FF41' }}>
+                  <span className="hidden md:inline">
+                    {RESTART_FINAL_DESKTOP.slice(0, typingChar)}
+                  </span>
+                  <span className="md:hidden">
+                    {RESTART_FINAL_MOBILE.slice(0, Math.min(typingChar, RESTART_FINAL_MOBILE.length))}
+                  </span>
+                  <span className={typingDone ? 'animate-blink' : ''}>&#x2588;</span>
+                </p>
+              )}
             </div>
           )}
         </div>

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -21,6 +21,14 @@ const SHUTDOWN_MESSAGES = [
   'System halted.',
 ];
 
+const RESTART_LINES = [
+  { text: 'Reboot scheduled.', color: '#888' },
+  { text: 'Waiting for user input...', color: '#888' },
+];
+
+const RESTART_FINAL_DESKTOP = 'Press any key to continue... ';
+const RESTART_FINAL_MOBILE = 'Tap to continue... ';
+
 type ShutdownPhase = null | 'messages' | 'crt-off' | 'black' | 'restart-prompt';
 
 const App: React.FC = () => {

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -29,6 +29,12 @@ const RESTART_LINES = [
 const RESTART_FINAL_DESKTOP = 'Press any key to continue... ';
 const RESTART_FINAL_MOBILE = 'Tap to continue... ';
 
+const RESTART_ALL_TEXTS = [
+  RESTART_LINES[0].text,
+  RESTART_LINES[1].text,
+  RESTART_FINAL_DESKTOP,
+];
+
 type ShutdownPhase = null | 'messages' | 'crt-off' | 'black' | 'restart-prompt';
 
 const App: React.FC = () => {
@@ -92,13 +98,7 @@ const App: React.FC = () => {
   useEffect(() => {
     if (shutdownPhase !== 'restart-prompt' || typingDone) return;
 
-    const allLines = [
-      RESTART_LINES[0].text,
-      RESTART_LINES[1].text,
-      RESTART_FINAL_DESKTOP,
-    ];
-
-    const currentText = allLines[typingLine];
+    const currentText = RESTART_ALL_TEXTS[typingLine];
     if (!currentText) return;
 
     if (typingChar < currentText.length) {
@@ -106,7 +106,7 @@ const App: React.FC = () => {
       return () => clearTimeout(timer);
     }
 
-    if (typingLine < allLines.length - 1) {
+    if (typingLine < RESTART_ALL_TEXTS.length - 1) {
       const timer = setTimeout(() => {
         setTypingLine(l => l + 1);
         setTypingChar(0);
@@ -115,7 +115,7 @@ const App: React.FC = () => {
     }
 
     setTypingDone(true);
-  }, [shutdownPhase, typingLine, typingChar, typingDone]);
+  }, [shutdownPhase, typingLine, typingChar]);
 
   // Attach restart listener only after typing completes
   useEffect(() => {

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -86,7 +86,7 @@ const App: React.FC = () => {
     }
 
     return () => timers.forEach(clearTimeout);
-  }, [shutdownPhase, handleRestart]);
+  }, [shutdownPhase]);
 
   // Typing animation for restart prompt
   useEffect(() => {
@@ -168,11 +168,12 @@ const App: React.FC = () => {
               {typingLine < RESTART_LINES.length && (
                 <p className={typingLine === 0 ? 'mb-1' : 'mb-4'} style={{ color: RESTART_LINES[typingLine].color }}>
                   {RESTART_LINES[typingLine].text.slice(0, typingChar)}
-                  <span className={typingDone ? 'animate-blink' : ''}>&#x2588;</span>
+                  <span>&#x2588;</span>
                 </p>
               )}
 
-              {/* Line 3: green, responsive, shows after first 2 lines done */}
+              {/* Final line: green, responsive. On mobile the shorter text finishes
+                  before the desktop-driven timer, causing a brief solid-cursor pause. */}
               {typingLine >= RESTART_LINES.length && (
                 <p style={{ color: '#00FF41' }}>
                   <span className="hidden md:inline">

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -81,16 +81,8 @@ const App: React.FC = () => {
         timers.push(setTimeout(() => setShutdownPhase('restart-prompt'), 1000));
         break;
 
-      case 'restart-prompt': {
-        const onKey = (e: KeyboardEvent) => { e.preventDefault(); handleRestart(); };
-        const onTouch = (e: TouchEvent) => { e.preventDefault(); handleRestart(); };
-        window.addEventListener('keydown', onKey);
-        window.addEventListener('touchstart', onTouch);
-        return () => {
-          window.removeEventListener('keydown', onKey);
-          window.removeEventListener('touchstart', onTouch);
-        };
-      }
+      case 'restart-prompt':
+        break;
     }
 
     return () => timers.forEach(clearTimeout);
@@ -124,6 +116,20 @@ const App: React.FC = () => {
 
     setTypingDone(true);
   }, [shutdownPhase, typingLine, typingChar, typingDone]);
+
+  // Attach restart listener only after typing completes
+  useEffect(() => {
+    if (shutdownPhase !== 'restart-prompt' || !typingDone) return;
+
+    const onKey = (e: KeyboardEvent) => { e.preventDefault(); handleRestart(); };
+    const onTouch = (e: TouchEvent) => { e.preventDefault(); handleRestart(); };
+    window.addEventListener('keydown', onKey);
+    window.addEventListener('touchstart', onTouch);
+    return () => {
+      window.removeEventListener('keydown', onKey);
+      window.removeEventListener('touchstart', onTouch);
+    };
+  }, [shutdownPhase, typingDone, handleRestart]);
 
   return (
     <div className="flex flex-col overflow-hidden" style={{ background: '#000', height: '100dvh' }}>

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -39,6 +39,9 @@ const App: React.FC = () => {
   const [shutdownPhase, setShutdownPhase] = useState<ShutdownPhase>(null);
   const [shutdownLines, setShutdownLines] = useState(0);
   const [sessionKey, setSessionKey] = useState(0);
+  const [typingLine, setTypingLine] = useState(0);
+  const [typingChar, setTypingChar] = useState(0);
+  const [typingDone, setTypingDone] = useState(false);
 
   const handleShutdown = useCallback(() => {
     setShutdownPhase('messages');
@@ -47,6 +50,9 @@ const App: React.FC = () => {
 
   const handleRestart = useCallback(() => {
     resetPageLoadTime();
+    setTypingLine(0);
+    setTypingChar(0);
+    setTypingDone(false);
     setShutdownPhase(null);
     setShutdownLines(0);
     setSessionKey(k => k + 1);
@@ -89,6 +95,35 @@ const App: React.FC = () => {
 
     return () => timers.forEach(clearTimeout);
   }, [shutdownPhase, handleRestart]);
+
+  // Typing animation for restart prompt
+  useEffect(() => {
+    if (shutdownPhase !== 'restart-prompt' || typingDone) return;
+
+    const allLines = [
+      RESTART_LINES[0].text,
+      RESTART_LINES[1].text,
+      RESTART_FINAL_DESKTOP,
+    ];
+
+    const currentText = allLines[typingLine];
+    if (!currentText) return;
+
+    if (typingChar < currentText.length) {
+      const timer = setTimeout(() => setTypingChar(c => c + 1), 50);
+      return () => clearTimeout(timer);
+    }
+
+    if (typingLine < allLines.length - 1) {
+      const timer = setTimeout(() => {
+        setTypingLine(l => l + 1);
+        setTypingChar(0);
+      }, 400);
+      return () => clearTimeout(timer);
+    }
+
+    setTypingDone(true);
+  }, [shutdownPhase, typingLine, typingChar, typingDone]);
 
   return (
     <div className="flex flex-col overflow-hidden" style={{ background: '#000', height: '100dvh' }}>


### PR DESCRIPTION
## Summary
- Add character-by-character typing animation to the restart prompt screen (after `exit` command)
- Lines type sequentially at 50ms/char with 400ms pauses between lines, solid cursor follows typing position
- Cursor switches to blinking after all lines finish; keypress/tap listener only activates after typing completes

## Test Plan
- [ ] Run `exit` in terminal — shutdown messages play unchanged, then restart prompt types out line by line
- [ ] Verify cursor is solid during typing, switches to blinking after completion
- [ ] Verify keypresses during typing animation are ignored
- [ ] Press any key after typing completes — boot splash replays, terminal reloads
- [ ] Check mobile viewport shows "Tap to continue..." variant
- [ ] Repeat exit/restart cycle multiple times — no stale state

🤖 Generated with [Claude Code](https://claude.com/claude-code)