### PR TITLE
Redesign mobile terminal toolbar, remove duplicate Enter button

### DIFF
--- a/docs/plans/2026-03-03-context-menu-execute-on-select.md
+++ b/docs/plans/2026-03-03-context-menu-execute-on-select.md
@@ -1,0 +1,143 @@
+# Context Menu Execute-on-Select Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Make suggestion menu selection (Enter, Tab, or mouse click) execute the command immediately instead of requiring a second Enter press.
+
+**Architecture:** Two call sites in `Terminal.tsx` currently copy the selected command to the input — change both to call `handleCommand()` directly instead.
+
+**Tech Stack:** React, TypeScript
+
+---
+
+### Task 1: Update `selectSuggestion()` to Execute Directly
+
+**Files:**
+- Modify: `src/components/Terminal/Terminal.tsx:167-173`
+
+**Step 1: Edit `selectSuggestion()`**
+
+Replace the current implementation:
+
+```tsx
+// Current (line 167-173)
+const selectSuggestion = () => {
+  const selectedCommand = suggestions[selectedSuggestionIndex].command;
+  setInputCommand(selectedCommand);
+  setShowSuggestions(false);
+  setAutoSuggestion(null);
+  inputRef.current?.focus();
+};
+```
+
+With:
+
+```tsx
+const selectSuggestion = () => {
+  const selectedCommand = suggestions[selectedSuggestionIndex].command;
+  setShowSuggestions(false);
+  handleCommand(selectedCommand);
+  inputRef.current?.focus();
+};
+```
+
+Key changes:
+- Remove `setInputCommand(selectedCommand)` — no longer copying to input
+- Remove `setAutoSuggestion(null)` — `handleCommand()` already calls this
+- Replace with `handleCommand(selectedCommand)` — executes directly
+
+This single change covers keyboard Enter (`actionEnter`), keyboard Tab (`actionTab`), and mobile (`handleMobileAction`) since they all call `selectSuggestion()`.
+
+**Step 2: Commit**
+
+```bash
+git add src/components/Terminal/Terminal.tsx
+git commit -m "feat: execute command on suggestion selection via keyboard
+
+selectSuggestion() now calls handleCommand() directly instead of
+copying the command to the input box."
+```
+
+---
+
+### Task 2: Update Mouse Click Handler to Execute Directly
+
+**Files:**
+- Modify: `src/components/Terminal/Terminal.tsx:379-384`
+
+**Step 1: Edit the `onSelect` callback in `<Suggestions>`**
+
+Replace the current inline handler:
+
+```tsx
+// Current (line 379-384)
+onSelect={(command) => {
+  setInputCommand(command);
+  setShowSuggestions(false);
+  setAutoSuggestion(null);
+  inputRef.current?.focus();
+}}
+```
+
+With:
+
+```tsx
+onSelect={(command) => {
+  setShowSuggestions(false);
+  handleCommand(command);
+  inputRef.current?.focus();
+}}
+```
+
+Same logic as Task 1 — execute directly instead of copying to input.
+
+**Step 2: Commit**
+
+```bash
+git add src/components/Terminal/Terminal.tsx
+git commit -m "feat: execute command on suggestion click
+
+Mouse click on a suggestion now executes the command directly,
+matching the keyboard selection behavior."
+```
+
+---
+
+### Task 3: Manual Verification
+
+**Step 1: Start dev server**
+
+Run: `npm run dev`
+
+**Step 2: Verify keyboard flow**
+
+1. Press Tab → suggestion menu opens
+2. Use Up/Down arrows to navigate
+3. Press Enter → command executes immediately (no second Enter needed)
+4. Verify command appears in terminal output with `$` prefix
+5. Press Up arrow → verify executed command is in history
+
+**Step 3: Verify Tab-to-select flow**
+
+1. Press Tab → suggestion menu opens
+2. Navigate to a command
+3. Press Tab again → command executes immediately
+4. Verify output and history
+
+**Step 4: Verify mouse flow**
+
+1. Press Tab → suggestion menu opens
+2. Click a suggestion → command executes immediately
+3. Verify input is focused after execution
+
+**Step 5: Verify edge cases**
+
+1. Select `clear` from menu → terminal clears (no crash)
+2. Select `exit` from menu → shutdown sequence starts
+3. Verify Escape still dismisses menu without executing
+
+**Step 6: Commit verification note (optional)**
+
+```bash
+git commit --allow-empty -m "verify: context menu execute-on-select tested manually"
+```

--- a/docs/plans/2026-03-04-mobile-terminal-toolbar-redesign.md
+++ b/docs/plans/2026-03-04-mobile-terminal-toolbar-redesign.md
@@ -1,0 +1,62 @@
+# Mobile Terminal Toolbar Redesign
+
+**Date:** 2026-03-04
+**Branch:** feature/enter-button
+
+## Problem
+
+Two buttons perform the same "submit command" action on mobile:
+1. The `</>` (Code2) button to the right of the terminal input — always visible
+2. The "Enter" button in the mobile toolbar — visible on screens < 768px
+
+This confuses users who see two identical actions.
+
+## Design
+
+### 1. Remove the `</>` button entirely
+
+Delete the `<button>` with the `Code2` icon from `Terminal.tsx`.
+
+- Applies to all screen sizes (desktop + mobile)
+- Desktop users submit with keyboard Enter (standard terminal behavior)
+- Mobile users submit via the toolbar Enter button
+- The input field stretches to fill the freed space
+
+### 2. Redesign mobile toolbar
+
+**Current:** `[Tab] [↑] [↓] [Enter]` — all equal width, same styling
+
+**New:** `[≡ Cmds] [↑] [↓] [⏎ Enter]`
+
+| Button | Label | Icon | Style | Action (unchanged) |
+|--------|-------|------|-------|---------------------|
+| Cmds | `≡ Cmds` | `List` from lucide-react | Dark (`#111` bg, `#00FF41` text, `#333` border) | `tab` |
+| Up | `↑` | — | Dark (same) | `up` |
+| Down | `↓` | — | Dark (same) | `down` |
+| Enter | `⏎ Enter` | — | **Emphasized** (`#00FF41` bg, `#000` text) | `enter` |
+
+Key changes:
+- **Reorder**: Navigation arrows grouped together, action keys on edges
+- **Rename Tab → Cmds**: Clearer meaning for mobile users ("open command list" vs keyboard concept)
+- **Add List icon**: Visual reinforcement of the menu-opening action
+- **Emphasize Enter**: Green background makes it the obvious primary action
+- **Add symbols**: `≡` prefix on Cmds, `⏎` prefix on Enter for extra clarity
+
+### 3. No other changes
+
+- Desktop: No toolbar, keyboard handles everything
+- Suggestions system, auto-suggestion, command handling — all unchanged
+- No CSS or responsive logic changes beyond the toolbar
+- `inputMode="none"` stays (no native keyboard on mobile)
+
+## Files to modify
+
+1. `src/components/Terminal/Terminal.tsx` — Remove Code2 button and its import
+2. `src/App.tsx` — Update `mobileKeys` array (labels, order) and Enter button styling; add `List` icon import
+
+## Research
+
+Based on analysis of terminal emulator apps (Termux, iSH, Blink Shell, a-Shell):
+- None duplicate Enter in their toolbar — they rely on native keyboard
+- Toolbars contain only special/modifier keys (Tab, arrows, Ctrl, Esc)
+- This project intentionally disables native keyboard on mobile, making the toolbar the primary interaction method

--- a/docs/plans/2026-03-04-mobile-terminal-toolbar-redesign.md
+++ b/docs/plans/2026-03-04-mobile-terminal-toolbar-redesign.md
@@ -1,7 +1,14 @@
-# Mobile Terminal Toolbar Redesign
+# Mobile Terminal Toolbar Redesign — Implementation Plan
 
-**Date:** 2026-03-04
-**Branch:** feature/enter-button
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Remove duplicate Enter button and redesign the mobile toolbar for clarity.
+
+**Architecture:** Two surgical file edits — remove the Code2 submit button from Terminal.tsx, then update the mobileKeys config and toolbar rendering in App.tsx to use new labels, order, icons, and emphasis styling.
+
+**Tech Stack:** React, TypeScript, lucide-react, Tailwind CSS
+
+---
 
 ## Problem
 
@@ -9,50 +16,176 @@ Two buttons perform the same "submit command" action on mobile:
 1. The `</>` (Code2) button to the right of the terminal input — always visible
 2. The "Enter" button in the mobile toolbar — visible on screens < 768px
 
-This confuses users who see two identical actions.
-
 ## Design
 
-### 1. Remove the `</>` button entirely
+**Current mobile toolbar:** `[Tab] [↑] [↓] [Enter]` — all same styling
 
-Delete the `<button>` with the `Code2` icon from `Terminal.tsx`.
+**New mobile toolbar:** `[≡ Cmds] [↑] [↓] [⏎ Enter]` — Enter emphasized, Tab renamed
 
-- Applies to all screen sizes (desktop + mobile)
-- Desktop users submit with keyboard Enter (standard terminal behavior)
-- Mobile users submit via the toolbar Enter button
-- The input field stretches to fill the freed space
+---
 
-### 2. Redesign mobile toolbar
+### Task 1: Remove the Code2 submit button from Terminal.tsx
 
-**Current:** `[Tab] [↑] [↓] [Enter]` — all equal width, same styling
+**Files:**
+- Modify: `src/components/Terminal/Terminal.tsx:2` (remove Code2 import)
+- Modify: `src/components/Terminal/Terminal.tsx:384-390` (delete button element)
 
-**New:** `[≡ Cmds] [↑] [↓] [⏎ Enter]`
+**Step 1: Remove Code2 from the import**
 
-| Button | Label | Icon | Style | Action (unchanged) |
-|--------|-------|------|-------|---------------------|
-| Cmds | `≡ Cmds` | `List` from lucide-react | Dark (`#111` bg, `#00FF41` text, `#333` border) | `tab` |
-| Up | `↑` | — | Dark (same) | `up` |
-| Down | `↓` | — | Dark (same) | `down` |
-| Enter | `⏎ Enter` | — | **Emphasized** (`#00FF41` bg, `#000` text) | `enter` |
+Change line 2 from:
+```tsx
+import { Code2, ChevronRight } from 'lucide-react';
+```
+to:
+```tsx
+import { ChevronRight } from 'lucide-react';
+```
 
-Key changes:
-- **Reorder**: Navigation arrows grouped together, action keys on edges
-- **Rename Tab → Cmds**: Clearer meaning for mobile users ("open command list" vs keyboard concept)
-- **Add List icon**: Visual reinforcement of the menu-opening action
-- **Emphasize Enter**: Green background makes it the obvious primary action
-- **Add symbols**: `≡` prefix on Cmds, `⏎` prefix on Enter for extra clarity
+**Step 2: Delete the Code2 button element**
 
-### 3. No other changes
+Remove the entire `<button>` block (lines 384–390):
+```tsx
+          <button
+            onClick={() => handleCommand(inputCommand)}
+            className="p-1.5 rounded hover:opacity-80 transition-opacity"
+            style={{ background: '#222', color: '#00FF41' }}
+          >
+            <Code2 className="w-4 h-4" />
+          </button>
+```
 
-- Desktop: No toolbar, keyboard handles everything
-- Suggestions system, auto-suggestion, command handling — all unchanged
-- No CSS or responsive logic changes beyond the toolbar
-- `inputMode="none"` stays (no native keyboard on mobile)
+**Step 3: Update placeholder text for mobile**
 
-## Files to modify
+On mobile, the placeholder currently says "Press Tab for suggestions..." — update it to match the new button label:
 
-1. `src/components/Terminal/Terminal.tsx` — Remove Code2 button and its import
-2. `src/App.tsx` — Update `mobileKeys` array (labels, order) and Enter button styling; add `List` icon import
+Change line 373 from:
+```tsx
+placeholder={isMobile ? "Press Tab for suggestions..." : "Type a command or press Tab for suggestions..."}
+```
+to:
+```tsx
+placeholder={isMobile ? "Tap Cmds for suggestions..." : "Type a command or press Tab for suggestions..."}
+```
+
+**Step 4: Verify the build compiles**
+
+Run: `npm run build`
+Expected: No errors, no unused import warnings
+
+**Step 5: Commit**
+
+```bash
+git add src/components/Terminal/Terminal.tsx
+git commit -m "Remove Code2 submit button from terminal input"
+```
+
+---
+
+### Task 2: Redesign mobile toolbar in App.tsx
+
+**Files:**
+- Modify: `src/App.tsx:1` (add List icon import)
+- Modify: `src/App.tsx:8-13` (update mobileKeys array)
+- Modify: `src/App.tsx:208-224` (update toolbar rendering for icons and emphasis)
+
+**Step 1: Add List icon import**
+
+Change line 1 to add the List import from lucide-react. Since App.tsx doesn't currently import from lucide-react, add a new import:
+```tsx
+import { List } from 'lucide-react';
+```
+
+**Step 2: Update the mobileKeys array**
+
+Replace lines 8–13:
+```tsx
+const mobileKeys = [
+  { label: 'Tab', action: 'tab' as const },
+  { label: '↑', action: 'up' as const },
+  { label: '↓', action: 'down' as const },
+  { label: 'Enter', action: 'enter' as const },
+];
+```
+with:
+```tsx
+const mobileKeys = [
+  { label: 'Cmds', action: 'tab' as const, icon: true },
+  { label: '↑', action: 'up' as const },
+  { label: '↓', action: 'down' as const },
+  { label: '⏎ Enter', action: 'enter' as const, emphasized: true },
+];
+```
+
+**Step 3: Update the toolbar rendering**
+
+Replace the toolbar button rendering (lines 208–224):
+```tsx
+        {/* Mobile virtual keyboard shortcuts */}
+        <div
+          className="flex md:hidden shrink-0 gap-2 p-2 border-t"
+          style={{ borderColor: '#333' }}
+        >
+          {mobileKeys.map(({ label, action }) => (
+            <button
+              key={label}
+              className="flex-1 py-2 font-mono text-sm rounded"
+              style={{ background: '#111', color: '#00FF41', border: '1px solid #333' }}
+              data-mobile-action={action}
+              onClick={() => terminalRef.current?.handleMobileAction(action)}
+            >
+              {label}
+            </button>
+          ))}
+        </div>
+```
+with:
+```tsx
+        {/* Mobile virtual keyboard shortcuts */}
+        <div
+          className="flex md:hidden shrink-0 gap-2 p-2 border-t"
+          style={{ borderColor: '#333' }}
+        >
+          {mobileKeys.map(({ label, action, icon, emphasized }) => (
+            <button
+              key={label}
+              className="flex-1 py-2 font-mono text-sm rounded inline-flex items-center justify-center gap-1"
+              style={emphasized
+                ? { background: '#00FF41', color: '#000', border: '1px solid #00FF41' }
+                : { background: '#111', color: '#00FF41', border: '1px solid #333' }
+              }
+              data-mobile-action={action}
+              onClick={() => terminalRef.current?.handleMobileAction(action)}
+            >
+              {icon && <List className="w-3.5 h-3.5" />}
+              {label}
+            </button>
+          ))}
+        </div>
+```
+
+**Step 4: Verify the build compiles**
+
+Run: `npm run build`
+Expected: No errors
+
+**Step 5: Visual verification**
+
+Run: `npm run dev`
+Check at mobile viewport (< 768px):
+- Toolbar shows: `[≡ Cmds] [↑] [↓] [⏎ Enter]`
+- Cmds button has List icon + dark styling
+- Enter button has green background, black text
+- No `</>` button visible next to input
+- Tapping Cmds opens suggestions, tapping Enter submits
+
+**Step 6: Commit**
+
+```bash
+git add src/App.tsx
+git commit -m "Redesign mobile toolbar: rename Tab→Cmds, emphasize Enter"
+```
+
+---
 
 ## Research
 

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -4,12 +4,13 @@ import Sidebar from './components/Sidebar';
 import TerminalWindow from './components/TerminalWindow';
 import Terminal, { TerminalHandle } from './components/Terminal';
 import { resetPageLoadTime } from './constants';
+import { List } from 'lucide-react';
 
 const mobileKeys = [
-  { label: 'Tab', action: 'tab' as const },
+  { label: 'Cmds', action: 'tab' as const, icon: true },
   { label: '↑', action: 'up' as const },
   { label: '↓', action: 'down' as const },
-  { label: 'Enter', action: 'enter' as const },
+  { label: '⏎ Enter', action: 'enter' as const, emphasized: true },
 ];
 
 const SHUTDOWN_MESSAGES = [
@@ -210,14 +211,18 @@ const App: React.FC = () => {
           className="flex md:hidden shrink-0 gap-2 p-2 border-t"
           style={{ borderColor: '#333' }}
         >
-          {mobileKeys.map(({ label, action }) => (
+          {mobileKeys.map(({ label, action, icon, emphasized }) => (
             <button
               key={label}
-              className="flex-1 py-2 font-mono text-sm rounded"
-              style={{ background: '#111', color: '#00FF41', border: '1px solid #333' }}
+              className="flex-1 py-2 font-mono text-sm rounded inline-flex items-center justify-center gap-1"
+              style={emphasized
+                ? { background: '#00FF41', color: '#000', border: '1px solid #00FF41' }
+                : { background: '#111', color: '#00FF41', border: '1px solid #333' }
+              }
               data-mobile-action={action}
               onClick={() => terminalRef.current?.handleMobileAction(action)}
             >
+              {icon && <List className="w-3.5 h-3.5" />}
               {label}
             </button>
           ))}

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -6,6 +6,9 @@ import Terminal, { TerminalHandle } from './components/Terminal';
 import { resetPageLoadTime } from './constants';
 import { List } from 'lucide-react';
 
+const MOBILE_BTN_STYLE = { background: '#111', color: '#00FF41', border: '1px solid #333' } as const;
+const MOBILE_BTN_STYLE_EMPHASIZED = { background: '#00FF41', color: '#000', border: '1px solid #00FF41' } as const;
+
 const mobileKeys = [
   { label: 'Cmds', action: 'tab' as const, icon: true },
   { label: '↑', action: 'up' as const },
@@ -215,10 +218,7 @@ const App: React.FC = () => {
             <button
               key={label}
               className="flex-1 py-2 font-mono text-sm rounded inline-flex items-center justify-center gap-1"
-              style={emphasized
-                ? { background: '#00FF41', color: '#000', border: '1px solid #00FF41' }
-                : { background: '#111', color: '#00FF41', border: '1px solid #333' }
-              }
+              style={emphasized ? MOBILE_BTN_STYLE_EMPHASIZED : MOBILE_BTN_STYLE}
               data-mobile-action={action}
               onClick={() => terminalRef.current?.handleMobileAction(action)}
             >

--- a/src/components/Terminal/Terminal.tsx
+++ b/src/components/Terminal/Terminal.tsx
@@ -1,5 +1,5 @@
 import React, { useState, useEffect, useRef, useImperativeHandle, forwardRef } from 'react';
-import { Code2, ChevronRight } from 'lucide-react';
+import { ChevronRight } from 'lucide-react';
 import DOMPurify from 'dompurify';
 import { suggestions, commands } from './commands';
 import { TerminalLine } from './types';
@@ -370,7 +370,7 @@ const Terminal = forwardRef<TerminalHandle, TerminalProps>(({ onShutdown }, ref)
               onKeyDown={handleKeyDown}
               className="bg-transparent font-mono text-sm w-full focus:outline-none relative z-10"
               style={{ color: '#00FF41' }}
-              placeholder={isMobile ? "Press Tab for suggestions..." : "Type a command or press Tab for suggestions..."}
+              placeholder={isMobile ? "Tap Cmds for suggestions..." : "Type a command or press Tab for suggestions..."}
               inputMode={isMobile ? "none" : undefined}
               autoCapitalize="none"
               spellCheck={false}
@@ -381,13 +381,6 @@ const Terminal = forwardRef<TerminalHandle, TerminalProps>(({ onShutdown }, ref)
               suggestion={autoSuggestion}
             />
           </div>
-          <button
-            onClick={() => handleCommand(inputCommand)}
-            className="p-1.5 rounded hover:opacity-80 transition-opacity"
-            style={{ background: '#222', color: '#00FF41' }}
-          >
-            <Code2 className="w-4 h-4" />
-          </button>
         </div>
         {showSuggestions && (
           <Suggestions


### PR DESCRIPTION
## Summary
- Removed the `</>` (Code2) submit button from the terminal input area — it duplicated the mobile toolbar's Enter button
- Redesigned mobile toolbar from `[Tab] [↑] [↓] [Enter]` to `[≡ Cmds] [↑] [↓] [⏎ Enter]`
- Enter button now visually emphasized with green background as the primary action
- "Tab" renamed to "Cmds" with a List icon for clearer mobile UX

## Test plan
- [ ] Desktop: verify Enter key submits commands, no `</>` button visible
- [ ] Mobile (< 768px): verify toolbar shows `[≡ Cmds] [↑] [↓] [⏎ Enter]`
- [ ] Mobile: tap Cmds opens suggestions, tap Enter submits
- [ ] Mobile: Enter button has green background, other buttons have dark styling
- [ ] Mobile: placeholder reads "Tap Cmds for suggestions..."

🤖 Generated with [Claude Code](https://claude.com/claude-code)