### PR TITLE
Remove help as a typeable command

### DIFF
--- a/src/components/Terminal/Terminal.tsx
+++ b/src/components/Terminal/Terminal.tsx
@@ -61,19 +61,17 @@ const Terminal = forwardRef<TerminalHandle, TerminalProps>(({ onShutdown }, ref)
   const displayHelp = () => {
     return [
       { content: '$ help', type: 'input' as const, timestamp: getCurrentTime() },
-      ...commands.help.map((line) => ({
-        content: line,
-        type: 'output' as const,
-      })),
+      { content: 'Available commands:', type: 'output' as const },
       ...suggestions.map((_, i) => ({
         content: '',
         type: 'output' as const,
         helpEntry: { commandIndex: i },
       })),
-      ...commands._helpFooter.map((line) => ({
-        content: line,
-        type: 'output' as const,
-      })),
+      { content: '', type: 'output' as const },
+      { content: 'Tips:', type: 'output' as const },
+      { content: '  • Use ↑↓ arrows to navigate command history', type: 'output' as const },
+      { content: '  • Tab for autocomplete', type: 'output' as const },
+      { content: '  • Ctrl+L to clear', type: 'output' as const },
     ];
   };
 

--- a/src/components/Terminal/commands.tsx
+++ b/src/components/Terminal/commands.tsx
@@ -15,16 +15,6 @@ export const suggestions: CommandSuggestion[] = [
 ];
 
 export const commands: Record<string, string[]> = {
-  help: [
-    'Available commands:',
-  ],
-  _helpFooter: [
-    '',
-    'Tips:',
-    '  • Use ↑↓ arrows to navigate command history',
-    '  • Tab for autocomplete',
-    '  • Ctrl+L to clear',
-  ],
   skills: [
     'Programming Languages:',
     '  Java    ████████████ expert',


### PR DESCRIPTION
## Summary
- Removed `help` and `_helpFooter` entries from the `commands` registry since help output is always shown on initial load and after `clear`
- Inlined help header/footer content directly in `displayHelp()` — the only consumer
- Typing `help` now returns "Command not found" consistent with other unknown commands

## Test plan
- [ ] Verify initial load still shows full help output with icons and tips
- [ ] Verify `clear` resets terminal to help output
- [ ] Verify typing `help` returns "Command not found: help"
- [ ] Verify `_helpFooter` is no longer a recognized command

🤖 Generated with [Claude Code](https://claude.com/claude-code)