### PR TITLE
Add delayed command execution after context menu selection

### DIFF
--- a/docs/plans/2026-03-07-context-menu-delayed-execute-design.md
+++ b/docs/plans/2026-03-07-context-menu-delayed-execute-design.md
@@ -1,0 +1,23 @@
+# Context Menu: Delayed Command Execution
+
+## Problem
+When selecting a command from the suggestions menu (Tab/Enter/click), the command executes immediately without ever appearing in the input box. This feels abrupt and unnatural.
+
+## Solution
+After selecting a command from the suggestions menu:
+1. Close the suggestions menu
+2. Display the selected command name in the input box
+3. After 300ms, auto-execute the command
+
+If the user types during the 300ms delay, cancel the pending execution.
+
+## Scope
+- **File:** `src/components/Terminal/Terminal.tsx`
+- **All 3 selection methods** (Tab, Enter, click/tap) use the same delayed behavior
+
+## Implementation
+1. Add a ref to track the pending execution timeout
+2. Modify `selectSuggestion()` to set input value, close menu, and schedule execution after 300ms
+3. Update `<Suggestions>` `onSelect` callback to use `selectSuggestion()` instead of inline logic
+4. In `handleInputChange`, cancel any pending execution timeout
+5. Clean up timeout on unmount

--- a/src/components/Terminal/Suggestions.tsx
+++ b/src/components/Terminal/Suggestions.tsx
@@ -4,7 +4,7 @@ import { CommandSuggestion } from './types';
 interface SuggestionsProps {
   suggestions: CommandSuggestion[];
   selectedIndex: number;
-  onSelect: (command: string) => void;
+  onSelect: (index: number) => void;
   onMouseEnter: (index: number) => void;
 }
 
@@ -23,7 +23,7 @@ const Suggestions = React.forwardRef<HTMLDivElement, SuggestionsProps>(
             style={{
               background: index === selectedIndex ? 'var(--terminal-surface)' : 'transparent',
             }}
-            onClick={() => onSelect(suggestion.command)}
+            onClick={() => onSelect(index)}
             onMouseEnter={() => onMouseEnter(index)}
           >
             {suggestion.icon}

--- a/src/components/Terminal/Terminal.tsx
+++ b/src/components/Terminal/Terminal.tsx
@@ -48,6 +48,7 @@ const Terminal = forwardRef<TerminalHandle, TerminalProps>(({ onShutdown }, ref)
   const spinnerTimeouts = useRef(new Set<ReturnType<typeof setTimeout>>());
   const spinnerIdRef = useRef(0);
   const touchStartY = useRef<number | null>(null);
+  const pendingExecuteRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 
   const getCurrentTime = () => {
     return new Date().toLocaleTimeString('en-US', {
@@ -100,6 +101,10 @@ const Terminal = forwardRef<TerminalHandle, TerminalProps>(({ onShutdown }, ref)
   };
 
   const handleInputChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    if (pendingExecuteRef.current) {
+      clearTimeout(pendingExecuteRef.current);
+      pendingExecuteRef.current = null;
+    }
     const value = e.target.value;
     setInputCommand(value);
     updateAutoSuggestion(value);
@@ -219,11 +224,20 @@ const Terminal = forwardRef<TerminalHandle, TerminalProps>(({ onShutdown }, ref)
     spinnerTimeouts.current.add(timeoutId);
   };
 
-  const selectSuggestion = () => {
-    const selectedCommand = suggestions[selectedSuggestionIndex].command;
+  const selectSuggestion = (index: number) => {
+    const selectedCommand = suggestions[index].command;
     setShowSuggestions(false);
-    handleCommand(selectedCommand);
+    setInputCommand(selectedCommand);
+    setAutoSuggestion(null);
     inputRef.current?.focus();
+    if (pendingExecuteRef.current) {
+      clearTimeout(pendingExecuteRef.current);
+      pendingExecuteRef.current = null;
+    }
+    pendingExecuteRef.current = setTimeout(() => {
+      pendingExecuteRef.current = null;
+      handleCommand(selectedCommand);
+    }, 300);
   };
 
   const completeAutoSuggestion = () => {
@@ -237,7 +251,7 @@ const Terminal = forwardRef<TerminalHandle, TerminalProps>(({ onShutdown }, ref)
   // Extracted action handlers for both keyboard and mobile button use
   const actionTab = () => {
     if (showSuggestions) {
-      selectSuggestion();
+      selectSuggestion(selectedSuggestionIndex);
     } else if (autoSuggestion) {
       completeAutoSuggestion();
     } else {
@@ -274,7 +288,7 @@ const Terminal = forwardRef<TerminalHandle, TerminalProps>(({ onShutdown }, ref)
 
   const actionEnter = () => {
     if (showSuggestions) {
-      selectSuggestion();
+      selectSuggestion(selectedSuggestionIndex);
     } else {
       handleCommand(inputCommand);
     }
@@ -366,6 +380,7 @@ const Terminal = forwardRef<TerminalHandle, TerminalProps>(({ onShutdown }, ref)
     return () => {
       spinnerTimeouts.current.forEach(clearTimeout);
       spinnerTimeouts.current.clear();
+      if (pendingExecuteRef.current) clearTimeout(pendingExecuteRef.current);
     };
   }, []);
 
@@ -461,10 +476,8 @@ const Terminal = forwardRef<TerminalHandle, TerminalProps>(({ onShutdown }, ref)
             ref={suggestionsRef}
             suggestions={suggestions}
             selectedIndex={selectedSuggestionIndex}
-            onSelect={(command) => {
-              setShowSuggestions(false);
-              handleCommand(command);
-              inputRef.current?.focus();
+            onSelect={(index) => {
+              selectSuggestion(index);
             }}
             onMouseEnter={setSelectedSuggestionIndex}
           />


### PR DESCRIPTION
## Summary
- When selecting a command from the suggestions menu (Tab, Enter, or click/tap), the command name now appears in the input box for 300ms before auto-executing
- Typing during the delay cancels the pending execution, preventing accidental commands
- All three selection methods (Tab, Enter, click) use consistent behavior

## Test plan
- [ ] Open terminal, press Tab to show suggestions menu
- [ ] Navigate with arrow keys and press Tab/Enter — verify command appears in input briefly before executing
- [ ] Click a suggestion — verify same delayed behavior
- [ ] Select a suggestion, then quickly type before 300ms — verify execution is cancelled
- [ ] On mobile: tap Cmds button, select a command — verify delayed execution works
- [ ] Verify no regressions with auto-suggestion (typing partial commands)

🤖 Generated with [Claude Code](https://claude.com/claude-code)