### PR TITLE
Replace white/darcula/gruvbox themes with Tokyo Night and One Dark Pro

### DIFF
--- a/docs/plans/2026-03-07-theme-refinement-design.md
+++ b/docs/plans/2026-03-07-theme-refinement-design.md
@@ -1,0 +1,68 @@
+# Theme Refinement Design
+
+## Summary
+
+Replace white, darcula, and gruvbox themes with Tokyo Night and One Dark Pro. Final theme list: `green`, `amber`, `tokyo-night`, `one-dark-pro`.
+
+## Theme Color Palettes
+
+### Tokyo Night
+
+| Variable | Value |
+|---|---|
+| `--terminal-primary` | `#7AA2F7` |
+| `--terminal-primary-dim` | `#565F89` |
+| `--terminal-primary-dark` | `#3B4261` |
+| `--terminal-bg` | `#1A1B26` |
+| `--terminal-surface` | `#24283B` |
+| `--terminal-border` | `#3B4261` |
+| `--terminal-gray` | `#565F89` |
+| `--terminal-error` | `#F7768E` |
+| `--terminal-output` | `#A9B1D6` |
+| `--terminal-glow` | `rgba(122, 162, 247, 0.15)` |
+| `--terminal-glow-soft` | `rgba(122, 162, 247, 0.05)` |
+| `--terminal-scanline` | `rgba(0, 0, 0, 0.02)` |
+| `--terminal-vignette` | `rgba(0, 0, 0, 0.3)` |
+
+### One Dark Pro
+
+| Variable | Value |
+|---|---|
+| `--terminal-primary` | `#61AFEF` |
+| `--terminal-primary-dim` | `#5C6370` |
+| `--terminal-primary-dark` | `#4B5263` |
+| `--terminal-bg` | `#282C34` |
+| `--terminal-surface` | `#2C313A` |
+| `--terminal-border` | `#3E4452` |
+| `--terminal-gray` | `#5C6370` |
+| `--terminal-error` | `#E06C75` |
+| `--terminal-output` | `#ABB2BF` |
+| `--terminal-glow` | `rgba(97, 175, 239, 0.15)` |
+| `--terminal-glow-soft` | `rgba(97, 175, 239, 0.05)` |
+| `--terminal-scanline` | `rgba(0, 0, 0, 0.02)` |
+| `--terminal-vignette` | `rgba(0, 0, 0, 0.25)` |
+
+## Headshot Filters
+
+- **green:** `grayscale(100%) sepia(60%) hue-rotate(80deg) saturate(200%)`
+- **amber:** `grayscale(100%) sepia(80%) saturate(200%)`
+- **tokyo-night:** `grayscale(100%) sepia(20%) hue-rotate(190deg) saturate(200%) brightness(0.9)`
+- **one-dark-pro:** `grayscale(100%) sepia(15%) hue-rotate(180deg) saturate(150%) brightness(0.9)`
+
+## Easter Eggs (first use, localStorage-gated)
+
+- **Tokyo Night:** "Welcome to Neo-Tokyo. The night shift begins."
+  - Key: `dkoder-tokyo-night-seen`
+- **One Dark Pro:** "Dark mode activated. Your eyes will thank you."
+  - Key: `dkoder-one-dark-pro-seen`
+
+## Files to Update
+
+1. `src/index.css` - Remove white/darcula/gruvbox CSS, add tokyo-night and one-dark-pro
+2. `src/ThemeContext.tsx` - Update ThemeName type and VALID_THEMES array
+3. `index.html` - Update inline script theme list
+4. `src/components/Sidebar.tsx` - Update HEADSHOT_FILTERS map
+
+## Migration
+
+Users with removed themes in localStorage fall back to green (default) via existing validation in getInitialTheme().

--- a/docs/plans/2026-03-07-theme-refinement-design.md
+++ b/docs/plans/2026-03-07-theme-refinement-design.md
@@ -1,68 +1,243 @@
-# Theme Refinement Design
+# Theme Refinement Implementation Plan
 
-## Summary
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
 
-Replace white, darcula, and gruvbox themes with Tokyo Night and One Dark Pro. Final theme list: `green`, `amber`, `tokyo-night`, `one-dark-pro`.
+**Goal:** Replace white, darcula, and gruvbox themes with Tokyo Night and One Dark Pro.
 
-## Theme Color Palettes
+**Architecture:** Swap CSS custom property blocks, update the TypeScript union type and theme array, sync the inline FOUC-prevention script, update headshot filter map, and replace the gruvbox Easter egg with two new ones.
 
-### Tokyo Night
+**Tech Stack:** React 18, TypeScript, CSS custom properties, Vite
 
-| Variable | Value |
-|---|---|
-| `--terminal-primary` | `#7AA2F7` |
-| `--terminal-primary-dim` | `#565F89` |
-| `--terminal-primary-dark` | `#3B4261` |
-| `--terminal-bg` | `#1A1B26` |
-| `--terminal-surface` | `#24283B` |
-| `--terminal-border` | `#3B4261` |
-| `--terminal-gray` | `#565F89` |
-| `--terminal-error` | `#F7768E` |
-| `--terminal-output` | `#A9B1D6` |
-| `--terminal-glow` | `rgba(122, 162, 247, 0.15)` |
-| `--terminal-glow-soft` | `rgba(122, 162, 247, 0.05)` |
-| `--terminal-scanline` | `rgba(0, 0, 0, 0.02)` |
-| `--terminal-vignette` | `rgba(0, 0, 0, 0.3)` |
+---
 
-### One Dark Pro
+### Task 1: Update CSS theme definitions
 
-| Variable | Value |
-|---|---|
-| `--terminal-primary` | `#61AFEF` |
-| `--terminal-primary-dim` | `#5C6370` |
-| `--terminal-primary-dark` | `#4B5263` |
-| `--terminal-bg` | `#282C34` |
-| `--terminal-surface` | `#2C313A` |
-| `--terminal-border` | `#3E4452` |
-| `--terminal-gray` | `#5C6370` |
-| `--terminal-error` | `#E06C75` |
-| `--terminal-output` | `#ABB2BF` |
-| `--terminal-glow` | `rgba(97, 175, 239, 0.15)` |
-| `--terminal-glow-soft` | `rgba(97, 175, 239, 0.05)` |
-| `--terminal-scanline` | `rgba(0, 0, 0, 0.02)` |
-| `--terminal-vignette` | `rgba(0, 0, 0, 0.25)` |
+**Files:**
+- Modify: `src/index.css:40-94` (remove white, gruvbox, darcula blocks; add tokyo-night and one-dark-pro)
 
-## Headshot Filters
+**Step 1: Remove the three old theme blocks and add two new ones**
 
-- **green:** `grayscale(100%) sepia(60%) hue-rotate(80deg) saturate(200%)`
-- **amber:** `grayscale(100%) sepia(80%) saturate(200%)`
-- **tokyo-night:** `grayscale(100%) sepia(20%) hue-rotate(190deg) saturate(200%) brightness(0.9)`
-- **one-dark-pro:** `grayscale(100%) sepia(15%) hue-rotate(180deg) saturate(150%) brightness(0.9)`
+Replace lines 40-94 (the white, gruvbox, and darcula theme blocks) with:
 
-## Easter Eggs (first use, localStorage-gated)
+```css
+/* Theme: Tokyo Night */
+:root[data-theme="tokyo-night"] {
+  --terminal-primary: #7AA2F7;
+  --terminal-primary-dim: #565F89;
+  --terminal-primary-dark: #3B4261;
+  --terminal-bg: #1A1B26;
+  --terminal-surface: #24283B;
+  --terminal-border: #3B4261;
+  --terminal-gray: #565F89;
+  --terminal-error: #F7768E;
+  --terminal-output: #A9B1D6;
+  --terminal-glow: rgba(122, 162, 247, 0.15);
+  --terminal-glow-soft: rgba(122, 162, 247, 0.05);
+  --terminal-scanline: rgba(0, 0, 0, 0.02);
+  --terminal-vignette: rgba(0, 0, 0, 0.3);
+}
 
-- **Tokyo Night:** "Welcome to Neo-Tokyo. The night shift begins."
-  - Key: `dkoder-tokyo-night-seen`
-- **One Dark Pro:** "Dark mode activated. Your eyes will thank you."
-  - Key: `dkoder-one-dark-pro-seen`
+/* Theme: One Dark Pro */
+:root[data-theme="one-dark-pro"] {
+  --terminal-primary: #61AFEF;
+  --terminal-primary-dim: #5C6370;
+  --terminal-primary-dark: #4B5263;
+  --terminal-bg: #282C34;
+  --terminal-surface: #2C313A;
+  --terminal-border: #3E4452;
+  --terminal-gray: #5C6370;
+  --terminal-error: #E06C75;
+  --terminal-output: #ABB2BF;
+  --terminal-glow: rgba(97, 175, 239, 0.15);
+  --terminal-glow-soft: rgba(97, 175, 239, 0.05);
+  --terminal-scanline: rgba(0, 0, 0, 0.02);
+  --terminal-vignette: rgba(0, 0, 0, 0.25);
+}
+```
 
-## Files to Update
+**Step 2: Commit**
 
-1. `src/index.css` - Remove white/darcula/gruvbox CSS, add tokyo-night and one-dark-pro
-2. `src/ThemeContext.tsx` - Update ThemeName type and VALID_THEMES array
-3. `index.html` - Update inline script theme list
-4. `src/components/Sidebar.tsx` - Update HEADSHOT_FILTERS map
+```bash
+git add src/index.css
+git commit -m "Replace white/darcula/gruvbox CSS themes with tokyo-night and one-dark-pro"
+```
 
-## Migration
+---
 
-Users with removed themes in localStorage fall back to green (default) via existing validation in getInitialTheme().
+### Task 2: Update ThemeContext type and array
+
+**Files:**
+- Modify: `src/ThemeContext.tsx:3,6`
+
+**Step 1: Update the ThemeName type (line 3)**
+
+Replace:
+```ts
+export type ThemeName = 'green' | 'amber' | 'white' | 'darcula' | 'gruvbox';
+```
+With:
+```ts
+export type ThemeName = 'green' | 'amber' | 'tokyo-night' | 'one-dark-pro';
+```
+
+**Step 2: Update VALID_THEMES array (line 6)**
+
+Replace:
+```ts
+export const VALID_THEMES: ThemeName[] = ['green', 'amber', 'white', 'darcula', 'gruvbox'];
+```
+With:
+```ts
+export const VALID_THEMES: ThemeName[] = ['green', 'amber', 'tokyo-night', 'one-dark-pro'];
+```
+
+**Step 3: Commit**
+
+```bash
+git add src/ThemeContext.tsx
+git commit -m "Update ThemeName type and VALID_THEMES for new themes"
+```
+
+---
+
+### Task 3: Update index.html FOUC-prevention script
+
+**Files:**
+- Modify: `index.html:11`
+
+**Step 1: Update the inline theme list**
+
+Replace:
+```js
+if (t && ['green','amber','white','darcula','gruvbox'].includes(t)) {
+```
+With:
+```js
+if (t && ['green','amber','tokyo-night','one-dark-pro'].includes(t)) {
+```
+
+**Step 2: Commit**
+
+```bash
+git add index.html
+git commit -m "Sync index.html inline theme list with new themes"
+```
+
+---
+
+### Task 4: Update Sidebar headshot filters
+
+**Files:**
+- Modify: `src/components/Sidebar.tsx:6-12`
+
+**Step 1: Replace the HEADSHOT_FILTERS map**
+
+Replace:
+```ts
+const HEADSHOT_FILTERS: Record<ThemeName, string> = {
+  green: 'grayscale(100%) sepia(60%) hue-rotate(80deg) saturate(200%)',
+  amber: 'grayscale(100%) sepia(80%) saturate(200%)',
+  white: 'grayscale(100%)',
+  darcula: 'grayscale(100%) brightness(0.9) contrast(1.1)',
+  gruvbox: 'grayscale(100%) sepia(40%) saturate(150%)',
+};
+```
+With:
+```ts
+const HEADSHOT_FILTERS: Record<ThemeName, string> = {
+  green: 'grayscale(100%) sepia(60%) hue-rotate(80deg) saturate(200%)',
+  amber: 'grayscale(100%) sepia(80%) saturate(200%)',
+  'tokyo-night': 'grayscale(100%) sepia(20%) hue-rotate(190deg) saturate(200%) brightness(0.9)',
+  'one-dark-pro': 'grayscale(100%) sepia(15%) hue-rotate(180deg) saturate(150%) brightness(0.9)',
+};
+```
+
+**Step 2: Commit**
+
+```bash
+git add src/components/Sidebar.tsx
+git commit -m "Update headshot filters for tokyo-night and one-dark-pro"
+```
+
+---
+
+### Task 5: Replace Easter egg logic in Terminal
+
+**Files:**
+- Modify: `src/components/Terminal/Terminal.tsx:188-194`
+
+**Step 1: Replace the gruvbox Easter egg with two new Easter eggs**
+
+Replace:
+```ts
+          const isGruvboxFirstTime = arg === 'gruvbox' && !localStorage.getItem('dkoder-gruvbox-seen');
+          setTheme(arg as ThemeName);
+          if (isGruvboxFirstTime) {
+            localStorage.setItem('dkoder-gruvbox-seen', '1');
+            outputLines = [
+              { content: 'Monitor upgrade detected. Welcome to the 21st century.', type: 'output' },
+            ];
+          } else {
+```
+With:
+```ts
+          const easterEggs: Partial<Record<ThemeName, { key: string; message: string }>> = {
+            'tokyo-night': { key: 'dkoder-tokyo-night-seen', message: 'Welcome to Neo-Tokyo. The night shift begins.' },
+            'one-dark-pro': { key: 'dkoder-one-dark-pro-seen', message: 'Dark mode activated. Your eyes will thank you.' },
+          };
+          const egg = easterEggs[arg as ThemeName];
+          const isFirstTime = egg && !localStorage.getItem(egg.key);
+          setTheme(arg as ThemeName);
+          if (isFirstTime) {
+            localStorage.setItem(egg.key, '1');
+            outputLines = [
+              { content: egg.message, type: 'output' },
+            ];
+          } else {
+```
+
+**Step 2: Commit**
+
+```bash
+git add src/components/Terminal/Terminal.tsx
+git commit -m "Replace gruvbox Easter egg with tokyo-night and one-dark-pro Easter eggs"
+```
+
+---
+
+### Task 6: Visual verification
+
+**Step 1: Run the dev server**
+
+```bash
+npm run dev
+```
+
+**Step 2: Verify each theme visually**
+
+For each theme (green, amber, tokyo-night, one-dark-pro):
+1. Type `theme <name>` in terminal — confirm it switches
+2. Check headshot photo has correct color tint
+3. Check CRT glow/scanline effect looks right
+4. Check the suggestions panel → theme sub-menu renders correctly
+5. Check auto-suggestion works: type `theme tok` → should suggest `theme tokyo-night`
+6. On mobile viewport (Chrome DevTools): confirm suggestions panel renders at correct touch-target size (min-h-[44px])
+
+**Step 3: Verify Easter eggs**
+
+1. Clear localStorage: `localStorage.clear()` in console
+2. Type `theme tokyo-night` → should show "Welcome to Neo-Tokyo. The night shift begins."
+3. Type `theme tokyo-night` again → should show "Theme switched to tokyo-night."
+4. Type `theme one-dark-pro` → should show "Dark mode activated. Your eyes will thank you."
+
+**Step 4: Verify migration**
+
+1. In console: `localStorage.setItem('dkoder-theme', 'gruvbox')`
+2. Refresh page → should fall back to green theme
+
+**Step 5: Build check**
+
+```bash
+npm run build
+```
+Expected: Clean build, no TypeScript errors (exhaustive ThemeName checking in Sidebar will catch missing entries at compile time).

--- a/index.html
+++ b/index.html
@@ -8,7 +8,7 @@
     <script>
       (function() {
         var t = localStorage.getItem('dkoder-theme');
-        if (t && ['green','amber','white','darcula','gruvbox'].includes(t)) {
+        if (t && ['green','amber','tokyo-night','one-dark-pro'].includes(t)) {
           document.documentElement.setAttribute('data-theme', t);
         }
       })();

--- a/src/ThemeContext.tsx
+++ b/src/ThemeContext.tsx
@@ -1,9 +1,9 @@
 import React, { createContext, useContext, useState, useCallback, useEffect, useRef } from 'react';
 
-export type ThemeName = 'green' | 'amber' | 'white' | 'darcula' | 'gruvbox';
+export type ThemeName = 'green' | 'amber' | 'tokyo-night' | 'one-dark-pro';
 
 // Also referenced in index.html inline script (can't import there)
-export const VALID_THEMES: ThemeName[] = ['green', 'amber', 'white', 'darcula', 'gruvbox'];
+export const VALID_THEMES: ThemeName[] = ['green', 'amber', 'tokyo-night', 'one-dark-pro'];
 const STORAGE_KEY = 'dkoder-theme';
 
 interface ThemeContextType {

--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -6,9 +6,8 @@ import { useTheme, ThemeName } from '../ThemeContext';
 const HEADSHOT_FILTERS: Record<ThemeName, string> = {
   green: 'grayscale(100%) sepia(60%) hue-rotate(80deg) saturate(200%)',
   amber: 'grayscale(100%) sepia(80%) saturate(200%)',
-  white: 'grayscale(100%)',
-  darcula: 'grayscale(100%) brightness(0.9) contrast(1.1)',
-  gruvbox: 'grayscale(100%) sepia(40%) saturate(150%)',
+  'tokyo-night': 'grayscale(100%) sepia(20%) hue-rotate(190deg) saturate(200%) brightness(0.9)',
+  'one-dark-pro': 'grayscale(100%) sepia(15%) hue-rotate(180deg) saturate(150%) brightness(0.9)',
 };
 
 const Sidebar: React.FC = () => {

--- a/src/components/Terminal/Terminal.tsx
+++ b/src/components/Terminal/Terminal.tsx
@@ -185,12 +185,17 @@ const Terminal = forwardRef<TerminalHandle, TerminalProps>(({ onShutdown }, ref)
             { content: `Usage: theme <name>`, type: 'output' },
           ];
         } else if (VALID_THEMES.includes(arg as ThemeName)) {
-          const isGruvboxFirstTime = arg === 'gruvbox' && !localStorage.getItem('dkoder-gruvbox-seen');
+          const easterEggs: Partial<Record<ThemeName, { key: string; message: string }>> = {
+            'tokyo-night': { key: 'dkoder-tokyo-night-seen', message: 'Welcome to Neo-Tokyo. The night shift begins.' },
+            'one-dark-pro': { key: 'dkoder-one-dark-pro-seen', message: 'Dark mode activated. Your eyes will thank you.' },
+          };
+          const egg = easterEggs[arg as ThemeName];
+          const isFirstTime = egg && !localStorage.getItem(egg.key);
           setTheme(arg as ThemeName);
-          if (isGruvboxFirstTime) {
-            localStorage.setItem('dkoder-gruvbox-seen', '1');
+          if (isFirstTime) {
+            localStorage.setItem(egg.key, '1');
             outputLines = [
-              { content: 'Monitor upgrade detected. Welcome to the 21st century.', type: 'output' },
+              { content: egg.message, type: 'output' },
             ];
           } else {
             outputLines = [

--- a/src/components/Terminal/Terminal.tsx
+++ b/src/components/Terminal/Terminal.tsx
@@ -10,6 +10,10 @@ import { useTheme, ThemeName, VALID_THEMES } from '../../ThemeContext';
 
 const MAX_HISTORY = 50;
 const PURIFY_CONFIG = { ADD_ATTR: ['target', 'style'], ADD_TAGS: ['svg', 'path', 'rect', 'circle', 'polyline'] };
+const THEME_EASTER_EGGS: Partial<Record<ThemeName, string>> = {
+  'tokyo-night': 'Welcome to Neo-Tokyo. The night shift begins.',
+  'one-dark-pro': 'Dark mode activated. Your eyes will thank you.',
+};
 
 export type TerminalHandle = {
   handleMobileAction: (action: 'tab' | 'up' | 'down' | 'enter') => void;
@@ -83,7 +87,7 @@ const Terminal = forwardRef<TerminalHandle, TerminalProps>(({ onShutdown }, ref)
       return;
     }
 
-    // Suggest theme arguments: "theme gr" → "theme gruvbox"
+    // Suggest theme arguments: "theme tok" → "theme tokyo-night"
     const lower = input.toLowerCase();
     if (lower.startsWith('theme ') && lower.length > 6) {
       const partial = lower.slice(6);
@@ -185,17 +189,14 @@ const Terminal = forwardRef<TerminalHandle, TerminalProps>(({ onShutdown }, ref)
             { content: `Usage: theme <name>`, type: 'output' },
           ];
         } else if (VALID_THEMES.includes(arg as ThemeName)) {
-          const easterEggs: Partial<Record<ThemeName, { key: string; message: string }>> = {
-            'tokyo-night': { key: 'dkoder-tokyo-night-seen', message: 'Welcome to Neo-Tokyo. The night shift begins.' },
-            'one-dark-pro': { key: 'dkoder-one-dark-pro-seen', message: 'Dark mode activated. Your eyes will thank you.' },
-          };
-          const egg = easterEggs[arg as ThemeName];
-          const isFirstTime = egg && !localStorage.getItem(egg.key);
+          const eggMessage = THEME_EASTER_EGGS[arg as ThemeName];
+          const eggKey = `dkoder-${arg}-seen`;
+          const isFirstTime = eggMessage && !localStorage.getItem(eggKey);
           setTheme(arg as ThemeName);
           if (isFirstTime) {
-            localStorage.setItem(egg.key, '1');
+            localStorage.setItem(eggKey, '1');
             outputLines = [
-              { content: egg.message, type: 'output' },
+              { content: eggMessage, type: 'output' },
             ];
           } else {
             outputLines = [

--- a/src/index.css
+++ b/src/index.css
@@ -37,58 +37,36 @@
   --terminal-vignette: rgba(10, 6, 0, 0.5);
 }
 
-/* Theme: White phosphor */
-:root[data-theme="white"] {
-  --terminal-primary: #B0B0B0;
-  --terminal-primary-dim: #888888;
-  --terminal-primary-dark: #444444;
-  --terminal-bg: #050505;
-  --terminal-surface: #0E0E0E;
-  --terminal-border: #333333;
-  --terminal-gray: #606060;
-  --terminal-error: #FF4444;
-  --terminal-output: #c0c0c0;
-  --terminal-glow: rgba(176, 176, 176, 0.3);
-  --terminal-glow-soft: rgba(176, 176, 176, 0.1);
-  --terminal-scanline: rgba(176, 176, 176, 0.03);
-  --terminal-vignette: rgba(5, 5, 5, 0.5);
-}
-
-/* Theme: Gruvbox (modern Easter egg) */
-:root[data-theme="gruvbox"] {
-  --terminal-primary: #EBDBB2;
-  --terminal-primary-dim: #A89984;
-  --terminal-primary-dark: #504945;
-  --terminal-bg: #1D2021;
-  --terminal-surface: #282828;
-  --terminal-border: #333333;
-  --terminal-gray: #928374;
-  --terminal-error: #FB4934;
-  --terminal-output: #D5C4A1;
-  --terminal-glow: rgba(235, 219, 178, 0.15);
-  --terminal-glow-soft: rgba(235, 219, 178, 0.05);
+/* Theme: Tokyo Night */
+:root[data-theme="tokyo-night"] {
+  --terminal-primary: #7AA2F7;
+  --terminal-primary-dim: #565F89;
+  --terminal-primary-dark: #3B4261;
+  --terminal-bg: #1A1B26;
+  --terminal-surface: #24283B;
+  --terminal-border: #3B4261;
+  --terminal-gray: #565F89;
+  --terminal-error: #F7768E;
+  --terminal-output: #A9B1D6;
+  --terminal-glow: rgba(122, 162, 247, 0.15);
+  --terminal-glow-soft: rgba(122, 162, 247, 0.05);
   --terminal-scanline: rgba(0, 0, 0, 0.02);
   --terminal-vignette: rgba(0, 0, 0, 0.3);
-  --terminal-accent-green: #B8BB26;
-  --terminal-accent-yellow: #FABD2F;
-  --terminal-accent-blue: #83A598;
-  --terminal-accent-orange: #FE8019;
-  --terminal-accent-purple: #D3869B;
 }
 
-/* Theme: Darcula (JetBrains-inspired) */
-:root[data-theme="darcula"] {
-  --terminal-primary: #A9B7C6;
-  --terminal-primary-dim: #6A8759;
-  --terminal-primary-dark: #555555;
-  --terminal-bg: #2B2B2B;
-  --terminal-surface: #313335;
-  --terminal-border: #333333;
-  --terminal-gray: #808080;
-  --terminal-error: #FF6B68;
-  --terminal-output: #BABABA;
-  --terminal-glow: rgba(169, 183, 198, 0.12);
-  --terminal-glow-soft: rgba(169, 183, 198, 0.05);
+/* Theme: One Dark Pro */
+:root[data-theme="one-dark-pro"] {
+  --terminal-primary: #61AFEF;
+  --terminal-primary-dim: #5C6370;
+  --terminal-primary-dark: #4B5263;
+  --terminal-bg: #282C34;
+  --terminal-surface: #2C313A;
+  --terminal-border: #3E4452;
+  --terminal-gray: #5C6370;
+  --terminal-error: #E06C75;
+  --terminal-output: #ABB2BF;
+  --terminal-glow: rgba(97, 175, 239, 0.15);
+  --terminal-glow-soft: rgba(97, 175, 239, 0.05);
   --terminal-scanline: rgba(0, 0, 0, 0.02);
   --terminal-vignette: rgba(0, 0, 0, 0.25);
 }


### PR DESCRIPTION
## Summary
- Drop 3 barely distinguishable themes (white, darcula, gruvbox) and add 2 modern alternatives: **Tokyo Night** and **One Dark Pro** with accurate color palettes
- Each new theme includes a first-use Easter egg message and matching headshot filter tint
- Theme selection works via terminal command (`theme tokyo-night`), auto-suggestions, and the context menu sub-menu on both desktop and mobile

## Changes
- `src/index.css` — Replaced 3 CSS theme blocks with 2 new ones (net -22 lines)
- `src/ThemeContext.tsx` — Updated `ThemeName` type union and `VALID_THEMES` array
- `index.html` — Synced inline FOUC-prevention script theme list
- `src/components/Sidebar.tsx` — Updated `HEADSHOT_FILTERS` with new theme tints
- `src/components/Terminal/Terminal.tsx` — Replaced gruvbox Easter egg with data-driven approach for both new themes

## Test plan
- [ ] Switch to each theme via `theme <name>` command — verify colors match spec
- [ ] Verify headshot photo tints match each theme's palette
- [ ] Verify Easter eggs fire on first use: "Welcome to Neo-Tokyo..." (tokyo-night), "Dark mode activated..." (one-dark-pro)
- [ ] Verify Easter eggs don't fire on subsequent use
- [ ] Verify auto-suggestion: type `theme tok` → suggests `theme tokyo-night`
- [ ] Verify theme sub-menu in suggestions panel (desktop + mobile)
- [ ] Verify users with old themes in localStorage fall back to green on reload
- [ ] Verify `npm run build` passes cleanly

🤖 Generated with [Claude Code](https://claude.com/claude-code)