### PR TITLE
Remove swipe-to-navigate-history gesture on mobile

### DIFF
--- a/docs/superpowers/plans/2026-03-14-remove-swipe-history-gesture.md
+++ b/docs/superpowers/plans/2026-03-14-remove-swipe-history-gesture.md
@@ -1,0 +1,117 @@
+# Remove Swipe-to-Navigate-History Gesture Implementation Plan
+
+> **For agentic workers:** REQUIRED: Use superpowers:subagent-driven-development (if subagents available) or superpowers:executing-plans to implement this plan. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Remove the swipe gesture that conflicts with native touch scrolling on mobile, restoring clean scroll behavior.
+
+**Architecture:** Pure deletion of ~15 lines from Terminal.tsx — one ref, two handler functions, two JSX props. No new code. Mobile toolbar buttons already provide history navigation.
+
+**Tech Stack:** React 18, TypeScript
+
+**Spec:** `docs/superpowers/specs/2026-03-14-remove-swipe-history-gesture-design.md`
+
+---
+
+## File Structure
+
+- Modify: `src/components/Terminal/Terminal.tsx` (delete swipe-related code)
+- Update: `MEMORY.md` (remove swipe gesture references from project documentation)
+
+---
+
+## Chunk 1: Remove swipe gesture and update docs
+
+### Task 1: Remove swipe gesture code from Terminal.tsx
+
+**Files:**
+- Modify: `src/components/Terminal/Terminal.tsx:51,556-570,589-590`
+
+- [ ] **Step 1: Delete `touchStartY` ref**
+
+Remove line 51:
+```typescript
+// DELETE this line:
+const touchStartY = useRef<number | null>(null);
+```
+
+- [ ] **Step 2: Delete `handleTouchStart` and `handleTouchEnd` functions**
+
+Remove lines 556-570:
+```typescript
+// DELETE this entire block:
+const handleTouchStart = (e: React.TouchEvent) => {
+  touchStartY.current = e.touches[0].clientY;
+};
+
+const handleTouchEnd = (e: React.TouchEvent) => {
+  if (touchStartY.current === null) return;
+  const deltaY = touchStartY.current - e.changedTouches[0].clientY;
+  touchStartY.current = null;
+  if (Math.abs(deltaY) < 50) return;
+  if (deltaY > 0) {
+    actionUp();
+  } else {
+    actionDown();
+  }
+};
+```
+
+- [ ] **Step 3: Remove `onTouchStart`/`onTouchEnd` props from the scrollable div**
+
+In the JSX, remove the two touch handler props from the `terminalRef` div (lines 589-590):
+```tsx
+// BEFORE:
+<div
+  ref={terminalRef}
+  className="h-full overflow-y-auto overflow-x-hidden text-sm terminal-scroll"
+  style={{...}}
+  onTouchStart={handleTouchStart}
+  onTouchEnd={handleTouchEnd}
+>
+
+// AFTER:
+<div
+  ref={terminalRef}
+  className="h-full overflow-y-auto overflow-x-hidden text-sm terminal-scroll"
+  style={{...}}
+>
+```
+
+- [ ] **Step 4: Verify TypeScript compiles**
+
+Run: `npx tsc --noEmit`
+Expected: No errors (no other code references the deleted symbols)
+
+- [ ] **Step 5: Verify dev server runs**
+
+Run: `npm run dev` (check it starts without errors, then stop)
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/components/Terminal/Terminal.tsx
+git commit -m "Remove swipe-to-navigate-history gesture on mobile
+
+The vertical swipe gesture on the terminal output area conflicted with
+native touch scrolling. Mobile toolbar buttons already provide history
+navigation, making the gesture redundant."
+```
+
+### Task 2: Update MEMORY.md
+
+**Files:**
+- Modify: `.claude/projects/-Users-null-projects-dkoderinc-website/memory/MEMORY.md`
+
+- [ ] **Step 1: Remove swipe gesture references**
+
+Remove these lines from the "Patterns & Conventions" section:
+```
+- Swipe up/down on terminal area navigates command history (50px threshold)
+```
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add .claude/projects/-Users-null-projects-dkoderinc-website/memory/MEMORY.md
+git commit -m "docs: remove swipe gesture reference from memory"
+```

--- a/docs/superpowers/specs/2026-03-14-remove-swipe-history-gesture-design.md
+++ b/docs/superpowers/specs/2026-03-14-remove-swipe-history-gesture-design.md
@@ -1,0 +1,34 @@
+# Remove Swipe-to-Navigate-History Gesture
+
+**Date:** 2026-03-14
+**Status:** Approved
+
+## Problem
+
+The terminal's scrollable output area (`overflow-y-auto`) has `onTouchStart`/`onTouchEnd` handlers that capture vertical swipes (>50px) and trigger command history navigation. This conflicts with native touch scrolling on mobile: any scroll attempt that exceeds the 50px threshold also changes the command history. Since `handleTouchEnd` does not call `preventDefault()`, both actions fire simultaneously — the terminal scrolls AND the input changes to a history entry.
+
+The mobile toolbar already provides dedicated `[↑]` and `[↓]` buttons for history navigation, making the swipe gesture entirely redundant.
+
+## Solution
+
+Remove all swipe-to-navigate-history code from `Terminal.tsx`:
+
+1. Delete `touchStartY` ref (line 51)
+2. Delete `handleTouchStart` function (lines 556-558)
+3. Delete `handleTouchEnd` function (lines 560-570)
+4. Remove `onTouchStart`/`onTouchEnd` props from the scrollable div (lines 589-590)
+
+## What stays unchanged
+
+- Mobile toolbar `[↑]`/`[↓]` buttons continue to handle history navigation via `handleMobileAction`
+- Desktop arrow key history navigation is unaffected
+- Native touch scrolling on the terminal output area works without interference (`overflow-y-auto`)
+
+## Risk
+
+None. `touchStartY`, `handleTouchStart`, and `handleTouchEnd` are not referenced by any other code. This is a pure deletion with no behavioral side effects beyond restoring clean touch scrolling.
+
+## Alternatives considered
+
+- **Smart swipe (scroll-boundary-only triggering):** Only fire history navigation when scrolled to bottom. Rejected — adds complexity for a redundant gesture.
+- **Horizontal swipe:** Use left/right swipe for history. Rejected — unconventional UX, still redundant with toolbar.

--- a/src/components/Terminal/Terminal.tsx
+++ b/src/components/Terminal/Terminal.tsx
@@ -48,7 +48,7 @@ const Terminal = forwardRef<TerminalHandle, TerminalProps>(({ onShutdown, onBell
   const suppressHoverRef = useRef(false);
   const spinnerTimeouts = useRef(new Set<ReturnType<typeof setTimeout>>());
   const spinnerIdRef = useRef(0);
-  const touchStartY = useRef<number | null>(null);
+
   const pendingExecuteRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const sentinelRef = useRef<HTMLDivElement>(null);
   const [showScrollIndicator, setShowScrollIndicator] = useState(false);
@@ -553,22 +553,6 @@ const Terminal = forwardRef<TerminalHandle, TerminalProps>(({ onShutdown, onBell
     onRevealStateChange?.(isInputBlocked);
   }, [revealingLines, onRevealStateChange]);
 
-  const handleTouchStart = (e: React.TouchEvent) => {
-    touchStartY.current = e.touches[0].clientY;
-  };
-
-  const handleTouchEnd = (e: React.TouchEvent) => {
-    if (touchStartY.current === null) return;
-    const deltaY = touchStartY.current - e.changedTouches[0].clientY;
-    touchStartY.current = null;
-    if (Math.abs(deltaY) < 50) return;
-    if (deltaY > 0) {
-      actionUp();
-    } else {
-      actionDown();
-    }
-  };
-
   return (
     <section ref={sectionRef} className="w-full flex flex-col flex-1 overflow-hidden p-4 terminal-glow crt-breathe" style={{ background: 'var(--terminal-bg)' }}>
       <div className="flex-1 relative overflow-hidden mb-4">
@@ -586,8 +570,6 @@ const Terminal = forwardRef<TerminalHandle, TerminalProps>(({ onShutdown, onBell
             opacity: rainVisible ? 0 : 1,
             transition: 'opacity 400ms ease-in-out',
           }}
-          onTouchStart={handleTouchStart}
-          onTouchEnd={handleTouchEnd}
         >
         {terminalOutput.map((line, index) => (
           <div key={index} className={`group flex items-start hover:bg-white/5 px-2 py-0.5 -mx-2 rounded ${


### PR DESCRIPTION
## Summary
- Removed vertical swipe gesture on the terminal output area that conflicted with native touch scrolling on mobile
- Mobile toolbar `[↑]`/`[↓]` buttons already provide history navigation, making the gesture redundant
- Pure deletion of ~20 lines — no new code

## Test plan
- [ ] On mobile (or device emulator), verify terminal output scrolls naturally with touch
- [ ] Verify toolbar `[↑]`/`[↓]` buttons still navigate command history
- [ ] Verify desktop arrow key history navigation is unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)