### PR TITLE
Add sound command enhancements: autocomplete, indicators, and shutdown sounds

### DIFF
--- a/docs/superpowers/plans/2026-03-14-sound-command-enhancements.md
+++ b/docs/superpowers/plans/2026-03-14-sound-command-enhancements.md
@@ -1,0 +1,275 @@
+# Sound Command Enhancements Implementation Plan
+
+> **For agentic workers:** REQUIRED: Use superpowers:subagent-driven-development (if subagents available) or superpowers:executing-plans to implement this plan. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add sound command autocomplete with on/off arguments, improve StatusBar sound indicator styling, and add synthesized shutdown/reboot sound effects.
+
+**Architecture:** Four targeted file edits — extend the sound engine with two new sound types, refactor the sound command handler to mirror the theme command pattern, add conditional styling to the StatusBar button, and wire shutdown/reboot sounds into App.tsx's state machine.
+
+**Tech Stack:** React 18, TypeScript, Web Audio API (existing useSoundEngine)
+
+**Spec:** `docs/superpowers/specs/2026-03-14-sound-command-enhancements-design.md`
+
+---
+
+## Chunk 1: Sound Engine & Terminal Changes
+
+### Task 1: Export SoundType and add new sound types
+
+**Files:**
+- Modify: `src/hooks/useSoundEngine.ts:3` (SoundType union)
+- Modify: `src/hooks/useSoundEngine.ts:55-90` (play() switch)
+
+- [ ] **Step 1: Export `SoundType` and add new members**
+
+At line 3, change:
+```typescript
+type SoundType = 'keypress' | 'execute' | 'error' | 'themeSwitch' | 'boot';
+```
+to:
+```typescript
+export type SoundType = 'keypress' | 'execute' | 'error' | 'themeSwitch' | 'boot' | 'shutdown' | 'systemType';
+```
+
+- [ ] **Step 2: Add `shutdown` case to the `play()` switch**
+
+After the `boot` case (line 88), before the closing `}` of the switch, add:
+
+```typescript
+      case 'shutdown': {
+        const notes = [660, 440, 220];
+        notes.forEach((freq, i) => {
+          setTimeout(() => playTone(freq, 80, 'sine', 0.04), i * 50);
+        });
+        break;
+      }
+```
+
+This mirrors the `boot` case (ascending 330→440→660) but descends 660→440→220 with slightly different timing (50ms stagger vs 70ms).
+
+- [ ] **Step 3: Add `systemType` case to the `play()` switch**
+
+After the new `shutdown` case, add:
+
+```typescript
+      case 'systemType':
+        playTone(600, 20, 'sine', 0.02);
+        break;
+```
+
+- [ ] **Step 4: Verify TypeScript compiles**
+
+Run: `npx tsc --noEmit`
+Expected: No errors.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/hooks/useSoundEngine.ts
+git commit -m "feat: add shutdown and systemType sounds to sound engine"
+```
+
+---
+
+### Task 2: Sound command autocomplete and handler refactor
+
+**Files:**
+- Modify: `src/components/Terminal/Terminal.tsx:117-139` (updateAutoSuggestion)
+- Modify: `src/components/Terminal/Terminal.tsx:260-265` (sound command handler)
+
+- [ ] **Step 1: Add sound argument autocomplete**
+
+In `updateAutoSuggestion` (line 117-139), add this block after the `theme ` check (after line 132) and before the generic command fallback (line 134):
+
+```typescript
+    // Suggest sound arguments: "sound o" → "sound on" / "sound of" → "sound off"
+    if (lower.startsWith('sound ') && lower.length > 6) {
+      const partial = lower.slice(6);
+      const match = ['on', 'off'].find(s => s.startsWith(partial));
+      if (match) {
+        setAutoSuggestion(`sound ${match}`);
+        return;
+      }
+    }
+```
+
+- [ ] **Step 2: Refactor sound command handler**
+
+Replace lines 260-265:
+```typescript
+      } else if (trimmedCmd === 'sound' || trimmedCmd === 'sound on' || trimmedCmd === 'sound off') {
+        const wantOn = trimmedCmd === 'sound' ? !soundEnabled : trimmedCmd === 'sound on';
+        onSoundSet?.(wantOn);
+        outputLines = [
+          { content: `Sound ${wantOn ? 'enabled' : 'disabled'}.`, type: 'output' },
+        ];
+```
+
+With:
+```typescript
+      } else if (trimmedCmd === 'sound' || trimmedCmd.startsWith('sound ')) {
+        const arg = trimmedCmd.replace('sound', '').trim();
+        if (!arg) {
+          outputLines = [
+            { content: `Sound: ${soundEnabled ? 'on' : 'off'}`, type: 'output' },
+            { content: `Usage: sound <on|off>`, type: 'output' },
+          ];
+        } else if (arg === 'on') {
+          onSoundSet?.(true);
+          outputLines = [
+            { content: 'Sound enabled.', type: 'output' },
+          ];
+        } else if (arg === 'off') {
+          onSoundSet?.(false);
+          outputLines = [
+            { content: 'Sound disabled.', type: 'output' },
+          ];
+        } else {
+          outputLines = [
+            { content: `Unknown option: ${arg}. Usage: sound <on|off>`, type: 'error' },
+          ];
+        }
+```
+
+- [ ] **Step 3: Verify TypeScript compiles**
+
+Run: `npx tsc --noEmit`
+Expected: No errors.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/components/Terminal/Terminal.tsx
+git commit -m "feat: add sound command autocomplete and help output"
+```
+
+---
+
+### Task 3: StatusBar sound indicator styling
+
+**Files:**
+- Modify: `src/components/StatusBar.tsx:46-53` (sound button)
+
+- [ ] **Step 1: Update sound button styling**
+
+Replace lines 46-53:
+```typescript
+            <button
+              className="status-bar-item cursor-pointer bg-transparent border-none p-0 font-mono"
+              style={{ color: 'var(--terminal-gray)', fontSize: 'inherit' }}
+              onClick={onSoundToggle}
+              title={soundEnabled ? 'Mute sounds' : 'Enable sounds'}
+            >
+              ♪ {soundEnabled ? 'on' : 'off'}
+            </button>
+```
+
+With:
+```typescript
+            <button
+              className="status-bar-item cursor-pointer bg-transparent border-none p-0 font-mono"
+              style={{
+                color: soundEnabled ? 'var(--terminal-primary)' : 'var(--terminal-gray)',
+                fontSize: 'inherit',
+                textDecoration: soundEnabled ? 'none' : 'line-through',
+              }}
+              onClick={onSoundToggle}
+              title={soundEnabled ? 'Mute sounds' : 'Enable sounds'}
+            >
+              ♪ {soundEnabled ? 'on' : 'off'}
+            </button>
+```
+
+- [ ] **Step 2: Verify TypeScript compiles**
+
+Run: `npx tsc --noEmit`
+Expected: No errors.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add src/components/StatusBar.tsx
+git commit -m "feat: add conditional styling to StatusBar sound indicator"
+```
+
+---
+
+## Chunk 2: Shutdown/Reboot Sounds
+
+### Task 4: Wire shutdown and reboot sounds into App.tsx
+
+**Files:**
+- Modify: `src/App.tsx:90-93` (handleShutdown callback)
+- Modify: `src/App.tsx:136-156` (typing animation useEffect)
+
+- [ ] **Step 1: Play shutdown sound in handleShutdown**
+
+Replace lines 90-93:
+```typescript
+  const handleShutdown = useCallback(() => {
+    setShutdownPhase('messages');
+    setShutdownLines(0);
+  }, []);
+```
+
+With:
+```typescript
+  const handleShutdown = useCallback(() => {
+    sound.play('shutdown');
+    setShutdownPhase('messages');
+    setShutdownLines(0);
+  }, [sound.play]);
+```
+
+Note: use `sound.play` (a `useCallback`-wrapped function) rather than `sound` (a fresh object each render) for a more precise dependency.
+
+- [ ] **Step 2: Play systemType sound per character during restart typing**
+
+In the typing animation effect (lines 136-156), modify the character-increment timer at line 143. Replace:
+
+```typescript
+      const timer = setTimeout(() => setTypingChar(c => c + 1), 50);
+```
+
+With:
+
+```typescript
+      const timer = setTimeout(() => {
+        sound.play('systemType');
+        setTypingChar(c => c + 1);
+      }, 50);
+```
+
+Important: `sound.play` is called inside the timer callback. Do NOT add `sound` to the effect's dependency array — the effect should continue to depend only on `[shutdownPhase, typingLine, typingChar]` to avoid re-triggering the animation. Add an ESLint suppression comment above the dependency array at line 156:
+
+```typescript
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [shutdownPhase, typingLine, typingChar]);
+```
+
+- [ ] **Step 3: Verify TypeScript compiles**
+
+Run: `npx tsc --noEmit`
+Expected: No errors.
+
+- [ ] **Step 4: Manual verification**
+
+Run: `npm run dev`
+
+Verify:
+1. Type `sound` → shows current state + usage
+2. Type `sound on` / `sound off` → enables/disables with message
+3. Type `sound foo` → error message
+4. Type `sound o` → autocomplete suggests `sound on`
+5. Type `sound of` → autocomplete suggests `sound off`
+6. StatusBar: `♪ on` is bright (terminal-primary), `♪ off` is gray with strikethrough
+7. Enable sound, type `exit` → hear descending tones during shutdown
+8. Restart prompt typing → hear soft per-character tones
+9. After restart → hear existing boot sound
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/App.tsx
+git commit -m "feat: add shutdown and reboot typing sound effects"
+```

--- a/docs/superpowers/specs/2026-03-14-sound-command-enhancements-design.md
+++ b/docs/superpowers/specs/2026-03-14-sound-command-enhancements-design.md
@@ -18,16 +18,28 @@ Add argument-level autocomplete for `sound on` / `sound off`, following the exis
 
 ### Command Handler (Terminal.tsx — command execution block)
 
-Replace the current toggle-on-bare-`sound` behavior with help output:
+Replace the current strict equality checks (`trimmedCmd === 'sound'`) with a `startsWith('sound')` check plus arg parsing, matching the `theme` command's conditional structure:
+
+```
+if (trimmedCmd === 'sound' || trimmedCmd.startsWith('sound ')) {
+  const arg = trimmedCmd.replace('sound', '').trim();
+  if (!arg) → show help
+  else if (arg === 'on') → enable
+  else if (arg === 'off') → disable
+  else → error
+}
+```
 
 | Input | Output |
 |-------|--------|
-| `sound` (no arg) | `"Sound: on/off"`, `"Usage: sound <on\|off>"` |
+| `sound` (no arg) | `"Sound: {current state}"`, `"Usage: sound <on\|off>"` |
 | `sound on` | Enable sound → `"Sound enabled."` |
 | `sound off` | Disable sound → `"Sound disabled."` |
 | `sound <invalid>` | `"Unknown option: X. Usage: sound <on\|off>"` |
 
-The StatusBar toggle remains the quick-access method for toggling without arguments.
+Note: bare `sound` shows the **current state** (e.g., `"Sound: on"`) consistent with how bare `theme` shows `"Current theme: green"`.
+
+The StatusBar toggle remains the quick-access method for toggling without arguments. The suggestion panel selecting `sound` will now show help text instead of toggling — this is acceptable and consistent with selecting bare `theme`.
 
 ## 2. StatusBar Sound Indicator
 
@@ -44,17 +56,25 @@ No structural changes. The button remains clickable in both states via the exist
 
 ### New Sound Types (useSoundEngine.ts)
 
-**`shutdown`** — Descending sine triad: 660 → 440 → 220 Hz. Each tone ~80ms duration, ~50ms stagger between tones. Mirrors the existing `boot` sound (330→440→660 ascending) but reversed for a "powering down" feel.
+Export the `SoundType` union from `useSoundEngine.ts` so it can be imported by other modules. Add two new members to the union:
 
-**`systemType`** — Single sine tone at ~600 Hz, ~20ms duration, volume ~0.02 (lower than the user's `keypress` at 0.03). Intended to sound like "the machine speaking" rather than "the user typing."
+**`shutdown`** — Descending sine triad: 660 → 440 → 220 Hz, oscillator type `'sine'`. Each tone ~80ms duration, volume 0.04, ~50ms stagger between tones. Mirrors the existing `boot` sound (330→440→660 ascending) but reversed for a "powering down" feel.
+
+**`systemType`** — Single sine tone at ~600 Hz, ~20ms duration, oscillator type `'sine'`, volume 0.02 (explicitly passed as 4th arg to `playTone`, which defaults to 0.04). Intended to sound like "the machine speaking" rather than the user's `keypress`.
+
+### Type Propagation
+
+The `playSound` prop in Terminal.tsx's `TerminalProps` uses a hardcoded literal union rather than importing `SoundType`. Since the new sounds (`shutdown`, `systemType`) are only triggered from App.tsx (which calls `sound.play()` directly), Terminal.tsx's prop type does **not** need updating. However, `SoundType` should be exported from `useSoundEngine.ts` to allow future consumers to reference it without duplication.
 
 ### Trigger Points (App.tsx)
 
-1. **`shutdown`** — Played once when `shutdownPhase` transitions to `'messages'`.
-2. **`systemType`** — Played per-character during the restart prompt typing animation (3 lines at 50ms/char intervals).
+1. **`shutdown`** — Call `sound.play('shutdown')` inside `handleShutdown` (synchronously when the user types `exit`, before the overlay renders). This is cleaner than placing it in the `useEffect` for the `'messages'` phase.
+
+2. **`systemType`** — Call `sound.play('systemType')` inside the `setTimeout` callback that increments `typingChar` during the restart prompt typing animation. Important: reference `sound.play` inside the timer callback only — do **not** add `sound` as an effect dependency, as this could re-trigger the animation loop if the `sound` object reference changes between renders.
+
 3. **`boot`** — Already plays on remount via BootSplash; no changes needed.
 
-No sounds during `crt-off` or `black` phases. The descending tones during messages provide the "powering down" feel; silence during CRT-off and blackout reinforces the dead-screen moment before the restart prompt begins.
+No sounds during `crt-off` or `black` phases. The descending tones at shutdown start provide the "powering down" feel; silence during CRT-off and blackout reinforces the dead-screen moment before the restart prompt begins.
 
 ### prefers-reduced-motion
 
@@ -64,7 +84,7 @@ All new sounds go through the existing `play()` method in `useSoundEngine`, whic
 
 | File | Changes |
 |------|---------|
-| `src/components/Terminal/Terminal.tsx` | Autocomplete for `sound` args; updated command handler with help output and error case |
+| `src/components/Terminal/Terminal.tsx` | Autocomplete for `sound` args; refactored command handler with `startsWith` + arg parsing |
 | `src/components/StatusBar.tsx` | Conditional color + text-decoration on sound button |
-| `src/hooks/useSoundEngine.ts` | Add `shutdown` and `systemType` to `SoundType` union and `play()` switch |
-| `src/App.tsx` | Trigger `shutdown` sound on phase transition; trigger `systemType` per-char in restart prompt |
+| `src/hooks/useSoundEngine.ts` | Export `SoundType`; add `shutdown` and `systemType` to union and `play()` switch |
+| `src/App.tsx` | Trigger `shutdown` in `handleShutdown`; trigger `systemType` per-char in restart prompt timer callback |

--- a/docs/superpowers/specs/2026-03-14-sound-command-enhancements-design.md
+++ b/docs/superpowers/specs/2026-03-14-sound-command-enhancements-design.md
@@ -1,0 +1,70 @@
+# Sound Command Enhancements Design
+
+**Date:** 2026-03-14
+**Status:** Draft
+
+## Overview
+
+Three enhancements to the terminal sound system: argument autocomplete for the `sound` command, improved StatusBar indicator styling, and synthesized sound effects for the shutdown/reboot sequence.
+
+## 1. Sound Command Autocomplete & Help Output
+
+### Autocomplete (Terminal.tsx — `updateAutoSuggestion`)
+
+Add argument-level autocomplete for `sound on` / `sound off`, following the existing `theme` autocomplete pattern. Insert a new block between the `theme ` prefix check and the generic command-level fallback:
+
+- If input starts with `"sound "` and has content after the space, match the partial against `['on', 'off']`.
+- If a match is found, suggest the full string (e.g., `"sound on"`).
+
+### Command Handler (Terminal.tsx — command execution block)
+
+Replace the current toggle-on-bare-`sound` behavior with help output:
+
+| Input | Output |
+|-------|--------|
+| `sound` (no arg) | `"Sound: on/off"`, `"Usage: sound <on\|off>"` |
+| `sound on` | Enable sound → `"Sound enabled."` |
+| `sound off` | Disable sound → `"Sound disabled."` |
+| `sound <invalid>` | `"Unknown option: X. Usage: sound <on\|off>"` |
+
+The StatusBar toggle remains the quick-access method for toggling without arguments.
+
+## 2. StatusBar Sound Indicator
+
+Update the existing `♪ on` / `♪ off` button in StatusBar.tsx with conditional styling:
+
+| State | Color | Text Decoration |
+|-------|-------|-----------------|
+| Sound on | `var(--terminal-primary)` | None |
+| Sound off | `var(--terminal-gray)` | `line-through` |
+
+No structural changes. The button remains clickable in both states via the existing `onSoundToggle` callback. Title attributes unchanged (`"Mute sounds"` / `"Enable sounds"`).
+
+## 3. Shutdown/Reboot Sounds
+
+### New Sound Types (useSoundEngine.ts)
+
+**`shutdown`** — Descending sine triad: 660 → 440 → 220 Hz. Each tone ~80ms duration, ~50ms stagger between tones. Mirrors the existing `boot` sound (330→440→660 ascending) but reversed for a "powering down" feel.
+
+**`systemType`** — Single sine tone at ~600 Hz, ~20ms duration, volume ~0.02 (lower than the user's `keypress` at 0.03). Intended to sound like "the machine speaking" rather than "the user typing."
+
+### Trigger Points (App.tsx)
+
+1. **`shutdown`** — Played once when `shutdownPhase` transitions to `'messages'`.
+2. **`systemType`** — Played per-character during the restart prompt typing animation (3 lines at 50ms/char intervals).
+3. **`boot`** — Already plays on remount via BootSplash; no changes needed.
+
+No sounds during `crt-off` or `black` phases. The descending tones during messages provide the "powering down" feel; silence during CRT-off and blackout reinforces the dead-screen moment before the restart prompt begins.
+
+### prefers-reduced-motion
+
+All new sounds go through the existing `play()` method in `useSoundEngine`, which already gates on `prefers-reduced-motion`. No additional checks needed.
+
+## Files Affected
+
+| File | Changes |
+|------|---------|
+| `src/components/Terminal/Terminal.tsx` | Autocomplete for `sound` args; updated command handler with help output and error case |
+| `src/components/StatusBar.tsx` | Conditional color + text-decoration on sound button |
+| `src/hooks/useSoundEngine.ts` | Add `shutdown` and `systemType` to `SoundType` union and `play()` switch |
+| `src/App.tsx` | Trigger `shutdown` sound on phase transition; trigger `systemType` per-char in restart prompt |

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -88,9 +88,10 @@ const App: React.FC = () => {
   const [typingDone, setTypingDone] = useState(false);
 
   const handleShutdown = useCallback(() => {
+    sound.play('shutdown');
     setShutdownPhase('messages');
     setShutdownLines(0);
-  }, []);
+  }, [sound.play]);
 
   const handleRestart = useCallback(() => {
     resetPageLoadTime();
@@ -140,7 +141,10 @@ const App: React.FC = () => {
     if (!currentText) return;
 
     if (typingChar < currentText.length) {
-      const timer = setTimeout(() => setTypingChar(c => c + 1), 50);
+      const timer = setTimeout(() => {
+        sound.play('systemType');
+        setTypingChar(c => c + 1);
+      }, 50);
       return () => clearTimeout(timer);
     }
 
@@ -153,6 +157,7 @@ const App: React.FC = () => {
     }
 
     setTypingDone(true);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [shutdownPhase, typingLine, typingChar]);
 
   // Attach restart listener only after typing completes

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -157,6 +157,9 @@ const App: React.FC = () => {
     }
 
     setTypingDone(true);
+    // sound.play omitted: adding it would restart the animation on sound toggle.
+    // Stale closure is acceptable — play() gates on enabled internally, and we want
+    // the sound state captured at animation start to persist through the sequence.
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [shutdownPhase, typingLine, typingChar]);
 

--- a/src/components/StatusBar.tsx
+++ b/src/components/StatusBar.tsx
@@ -45,7 +45,11 @@ const StatusBar: React.FC<StatusBarProps> = ({ onThemeClick, onSoundToggle, soun
             <span style={{ color: 'var(--terminal-border)' }}>│</span>
             <button
               className="status-bar-item cursor-pointer bg-transparent border-none p-0 font-mono"
-              style={{ color: 'var(--terminal-gray)', fontSize: 'inherit' }}
+              style={{
+                color: soundEnabled ? 'var(--terminal-primary)' : 'var(--terminal-gray)',
+                fontSize: 'inherit',
+                textDecoration: soundEnabled ? 'none' : 'line-through',
+              }}
               onClick={onSoundToggle}
               title={soundEnabled ? 'Mute sounds' : 'Enable sounds'}
             >

--- a/src/components/Terminal/Terminal.tsx
+++ b/src/components/Terminal/Terminal.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect, useRef, useImperativeHandle, forwardRef } from 'react';
+import React, { useState, useEffect, useRef, useImperativeHandle, forwardRef, useMemo } from 'react';
 import DOMPurify from 'dompurify';
 import { suggestions, commands } from './commands';
 import { Volume2, VolumeX } from 'lucide-react';
@@ -8,6 +8,7 @@ import AutoSuggestion from './AutoSuggestion';
 import { PAGE_LOAD_TIME, formatUptime } from '../../constants';
 import { useTheme, ThemeName, VALID_THEMES } from '../../ThemeContext';
 import useIsMobile from '../../hooks/useIsMobile';
+import { SoundType } from '../../hooks/useSoundEngine';
 import useIdleTimer from '../../hooks/useIdleTimer';
 import MatrixRain from './MatrixRain';
 
@@ -25,7 +26,7 @@ export type TerminalHandle = {
 type TerminalProps = {
   onShutdown?: () => void;
   onBell?: () => void;
-  playSound?: (sound: 'keypress' | 'execute' | 'error' | 'themeSwitch' | 'boot') => void;
+  playSound?: (sound: SoundType) => void;
   soundEnabled?: boolean;
   onSoundSet?: (enabled: boolean) => void;
   onRevealStateChange?: (isRevealing: boolean) => void;
@@ -61,14 +62,14 @@ const Terminal = forwardRef<TerminalHandle, TerminalProps>(({ onShutdown, onBell
   const isInputBlocked = revealingLines !== null;
 
   // Derive suggestions with dynamic sound icon based on current state
-  const displaySuggestions = suggestions.map(s =>
+  const displaySuggestions = useMemo(() => suggestions.map(s =>
     s.command === 'sound'
       ? { ...s, icon: soundEnabled
           ? <Volume2 className="w-4 h-4" style={{ color: 'var(--terminal-primary)' }} />
           : <VolumeX className="w-4 h-4" style={{ color: 'var(--terminal-primary)' }} />
         }
       : s
-  );
+  ), [soundEnabled]);
 
   // Matrix rain idle effect
   const reducedMotion = typeof window !== 'undefined'

--- a/src/components/Terminal/Terminal.tsx
+++ b/src/components/Terminal/Terminal.tsx
@@ -1,6 +1,7 @@
 import React, { useState, useEffect, useRef, useImperativeHandle, forwardRef } from 'react';
 import DOMPurify from 'dompurify';
 import { suggestions, commands } from './commands';
+import { Volume2, VolumeX } from 'lucide-react';
 import { TerminalLine } from './types';
 import Suggestions from './Suggestions';
 import AutoSuggestion from './AutoSuggestion';
@@ -58,6 +59,16 @@ const Terminal = forwardRef<TerminalHandle, TerminalProps>(({ onShutdown, onBell
   const revealLastTimeRef = useRef<number>(0);
   const revealStartIndexRef = useRef<number>(0);
   const isInputBlocked = revealingLines !== null;
+
+  // Derive suggestions with dynamic sound icon based on current state
+  const displaySuggestions = suggestions.map(s =>
+    s.command === 'sound'
+      ? { ...s, icon: soundEnabled
+          ? <Volume2 className="w-4 h-4" style={{ color: 'var(--terminal-primary)' }} />
+          : <VolumeX className="w-4 h-4" style={{ color: 'var(--terminal-primary)' }} />
+        }
+      : s
+  );
 
   // Matrix rain idle effect
   const reducedMotion = typeof window !== 'undefined'
@@ -368,6 +379,10 @@ const Terminal = forwardRef<TerminalHandle, TerminalProps>(({ onShutdown, onBell
         setSelectedSuggestionIndex(0);
         return;
       }
+      if (selectedCommand === 'sound') {
+        executeWithPreview(soundEnabled ? 'sound off' : 'sound on');
+        return;
+      }
       executeWithPreview(selectedCommand);
     } else {
       const selectedTheme = VALID_THEMES[index];
@@ -620,10 +635,10 @@ const Terminal = forwardRef<TerminalHandle, TerminalProps>(({ onShutdown, onBell
                 </span>
               ) : line.helpEntry ? (
                 <span className="inline-flex items-center gap-3">
-                  {suggestions[line.helpEntry.commandIndex].icon}
-                  <span style={{ color: 'var(--terminal-primary)' }}>{suggestions[line.helpEntry.commandIndex].command}</span>
+                  {displaySuggestions[line.helpEntry.commandIndex].icon}
+                  <span style={{ color: 'var(--terminal-primary)' }}>{displaySuggestions[line.helpEntry.commandIndex].command}</span>
                   <span style={{ color: 'var(--terminal-primary-dark)' }}>-</span>
-                  <span style={{ color: 'var(--terminal-gray)' }}>{suggestions[line.helpEntry.commandIndex].description}</span>
+                  <span style={{ color: 'var(--terminal-gray)' }}>{displaySuggestions[line.helpEntry.commandIndex].description}</span>
                 </span>
               ) : line.isHtml ? (
                 <span
@@ -692,7 +707,7 @@ const Terminal = forwardRef<TerminalHandle, TerminalProps>(({ onShutdown, onBell
         {showSuggestions && (
           <Suggestions
             ref={suggestionsRef}
-            suggestions={suggestions}
+            suggestions={displaySuggestions}
             selectedIndex={selectedSuggestionIndex}
             onSelect={selectSuggestion}
             onMouseEnter={(i) => { if (!suppressHoverRef.current) setSelectedSuggestionIndex(i); }}

--- a/src/components/Terminal/Terminal.tsx
+++ b/src/components/Terminal/Terminal.tsx
@@ -131,6 +131,16 @@ const Terminal = forwardRef<TerminalHandle, TerminalProps>(({ onShutdown, onBell
       }
     }
 
+    // Suggest sound arguments: "sound o" → "sound on" / "sound of" → "sound off"
+    if (lower.startsWith('sound ') && lower.length > 6) {
+      const partial = lower.slice(6);
+      const match = ['on', 'off'].find(s => s.startsWith(partial));
+      if (match) {
+        setAutoSuggestion(`sound ${match}`);
+        return;
+      }
+    }
+
     const matchingCommand = suggestions
       .map(s => s.command)
       .find(cmd => cmd.toLowerCase().startsWith(lower));
@@ -257,12 +267,28 @@ const Terminal = forwardRef<TerminalHandle, TerminalProps>(({ onShutdown, onBell
             { content: `Unknown theme: ${arg}. Available: ${VALID_THEMES.join(', ')}`, type: 'error' },
           ];
         }
-      } else if (trimmedCmd === 'sound' || trimmedCmd === 'sound on' || trimmedCmd === 'sound off') {
-        const wantOn = trimmedCmd === 'sound' ? !soundEnabled : trimmedCmd === 'sound on';
-        onSoundSet?.(wantOn);
-        outputLines = [
-          { content: `Sound ${wantOn ? 'enabled' : 'disabled'}.`, type: 'output' },
-        ];
+      } else if (trimmedCmd === 'sound' || trimmedCmd.startsWith('sound ')) {
+        const arg = trimmedCmd.replace('sound', '').trim();
+        if (!arg) {
+          outputLines = [
+            { content: `Sound: ${soundEnabled ? 'on' : 'off'}`, type: 'output' },
+            { content: `Usage: sound <on|off>`, type: 'output' },
+          ];
+        } else if (arg === 'on') {
+          onSoundSet?.(true);
+          outputLines = [
+            { content: 'Sound enabled.', type: 'output' },
+          ];
+        } else if (arg === 'off') {
+          onSoundSet?.(false);
+          outputLines = [
+            { content: 'Sound disabled.', type: 'output' },
+          ];
+        } else {
+          outputLines = [
+            { content: `Unknown option: ${arg}. Usage: sound <on|off>`, type: 'error' },
+          ];
+        }
       } else {
         const output = commands[trimmedCmd as keyof typeof commands] || `Command not found: ${cmd}`;
         if (typeof output === 'string' && output.startsWith('Command not found')) {

--- a/src/components/Terminal/commands.tsx
+++ b/src/components/Terminal/commands.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Cpu, Mail, Sparkles, User, Info, Clock, LogOut, History, Palette, Volume2 } from 'lucide-react';
+import { Cpu, Mail, Sparkles, User, Info, Clock, LogOut, History, Palette, Volume2, VolumeX } from 'lucide-react';
 import { CommandSuggestion } from './types';
 
 export const suggestions: CommandSuggestion[] = [

--- a/src/components/Terminal/commands.tsx
+++ b/src/components/Terminal/commands.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Cpu, Mail, Sparkles, User, Info, Clock, LogOut, History, Palette, Volume2, VolumeX } from 'lucide-react';
+import { Cpu, Mail, Sparkles, User, Info, Clock, LogOut, History, Palette, Volume2 } from 'lucide-react';
 import { CommandSuggestion } from './types';
 
 export const suggestions: CommandSuggestion[] = [

--- a/src/hooks/useSoundEngine.ts
+++ b/src/hooks/useSoundEngine.ts
@@ -1,6 +1,6 @@
 import { useCallback, useRef, useState, useEffect } from 'react';
 
-type SoundType = 'keypress' | 'execute' | 'error' | 'themeSwitch' | 'boot';
+export type SoundType = 'keypress' | 'execute' | 'error' | 'themeSwitch' | 'boot' | 'shutdown' | 'systemType';
 
 const STORAGE_KEY = 'dkoder-sound-enabled';
 
@@ -87,6 +87,16 @@ const useSoundEngine = () => {
         });
         break;
       }
+      case 'shutdown': {
+        const notes = [660, 440, 220];
+        notes.forEach((freq, i) => {
+          setTimeout(() => playTone(freq, 80, 'sine', 0.04), i * 50);
+        });
+        break;
+      }
+      case 'systemType':
+        playTone(600, 20, 'sine', 0.02);
+        break;
     }
   }, [enabled, playTone, getContext]);
 


### PR DESCRIPTION
## Summary
- **Sound command autocomplete**: `sound on` / `sound off` arguments with tab completion, matching the `theme` command pattern. Bare `sound` now shows current state + usage help. Invalid args get error messages.
- **Suggestions panel**: Selecting `sound` from the command panel toggles directly (executes `sound on` or `sound off` based on current state). Icon updates reactively — `Volume2` when on, `VolumeX` when off.
- **StatusBar indicator**: `♪ on` is bright (terminal-primary color), `♪ off` is gray with strikethrough for clear visual feedback.
- **Shutdown/reboot sounds**: Descending sine triad (660→440→220 Hz) on `exit`, soft per-character typing tones (600 Hz sine, low volume) during the restart prompt animation. Respects `prefers-reduced-motion`.
- **Code quality**: Exported `SoundType` union as single source of truth, `useMemo` on derived suggestions, documented ESLint suppression rationale.

## Test plan
- [ ] Type `sound` — shows current state + usage
- [ ] Type `sound on` / `sound off` — enables/disables with confirmation message
- [ ] Type `sound foo` — shows error with usage hint
- [ ] Type `sound o` then Tab — autocompletes to `sound on`
- [ ] Type `sound of` then Tab — autocompletes to `sound off`
- [ ] Open suggestions panel (Tab) — sound entry shows Volume2/VolumeX icon matching state
- [ ] Select `sound` from suggestions panel — toggles sound state directly
- [ ] StatusBar: `♪ on` is bright, `♪ off` is gray with strikethrough
- [ ] Enable sound, type `exit` — hear descending tones during shutdown messages
- [ ] Restart prompt typing — hear soft per-character system tones
- [ ] After restart — hear existing ascending boot sound
- [ ] Verify with `prefers-reduced-motion` enabled — no sounds play

🤖 Generated with [Claude Code](https://claude.com/claude-code)