### PR TITLE
fix: prevent terminal output truncation on mobile

### DIFF
--- a/src/components/Terminal/Terminal.tsx
+++ b/src/components/Terminal/Terminal.tsx
@@ -645,7 +645,7 @@ const Terminal = ({ onShutdown, onBell, playSound, soundEnabled, onSoundSet, onR
                   }}
                 />
               ) : (
-                <span style={{ whiteSpace: 'pre' }}>{line.content}</span>
+                <span style={{ whiteSpace: 'pre-wrap' }}>{line.content}</span>
               )}
             </p>
             <span className="text-xs mr-2 opacity-0 group-hover:opacity-100 select-none" style={{ color: 'var(--terminal-primary-dark)' }}>


### PR DESCRIPTION
Change white-space from 'pre' to 'pre-wrap' on plain-text output lines.
This preserves whitespace formatting (column alignment, indentation)
while allowing long lines to wrap at the container boundary instead of
being clipped by overflow-x-hidden on narrow viewports.

https://claude.ai/code/session_011546YBHyPu4FTYnCNmZvCV