### PR TITLE
Replace auto-displayed help with minimal MOTD hint

### DIFF
--- a/docs/superpowers/plans/2026-03-19-minimal-motd.md
+++ b/docs/superpowers/plans/2026-03-19-minimal-motd.md
@@ -1,0 +1,287 @@
+# Minimal MOTD Implementation Plan
+
+> **For agentic workers:** REQUIRED: Use superpowers:subagent-driven-development (if subagents available) or superpowers:executing-plans to implement this plan. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Replace the auto-displayed 17-line help output with a 1-line MOTD hint on load/clear, add `help` as a real command, and remove the redundant input placeholder.
+
+**Architecture:** Three surgical changes to Terminal.tsx (new `displayMotd()` function, new `help` early-return handler, placeholder removal), one addition to commands.tsx (help suggestion entry), and test updates.
+
+**Tech Stack:** React 19, TypeScript, Vitest, @testing-library/react
+
+**Spec:** `docs/superpowers/specs/2026-03-19-minimal-motd-design.md`
+
+---
+
+## Chunk 1: Implementation
+
+### Task 1: Add `help` to suggestions array
+
+**Files:**
+- Modify: `src/components/Terminal/commands.tsx:1-15`
+
+- [ ] **Step 1: Add HelpCircle import and help entry**
+
+In `commands.tsx`, add `HelpCircle` to the lucide-react import and add a `help` entry to the `suggestions` array — after `sound`, before `clear`:
+
+```tsx
+// Line 1 — add HelpCircle to import:
+import { Cpu, Mail, Sparkles, User, Info, Clock, LogOut, History, Palette, Volume2, HelpCircle } from 'lucide-react';
+
+// Insert after the sound entry (line 12), before clear (line 13):
+  { command: 'help', description: 'Show available commands', icon: <HelpCircle className="w-4 h-4" style={{ color: 'var(--terminal-primary)' }} /> },
+```
+
+The full suggestions array order becomes: whoami, man dmytro, skills, history, contact, uptime, theme, sound, **help**, clear, exit.
+
+- [ ] **Step 2: Verify build compiles**
+
+Run: `npx tsc --noEmit`
+Expected: No errors
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add src/components/Terminal/commands.tsx
+git commit -m "feat: add help to suggestions array for Tab-completion"
+```
+
+---
+
+### Task 2: Add `displayMotd()` and swap call sites
+
+**Files:**
+- Modify: `src/components/Terminal/Terminal.tsx:119-134` (add function), `Terminal.tsx:191` (clear handler), `Terminal.tsx:508` (mount effect), `Terminal.tsx:686` (placeholder)
+
+- [ ] **Step 1: Add `displayMotd()` function**
+
+Add the new function directly above the existing `displayHelp()` (before line 119):
+
+```tsx
+  const displayMotd = (): TerminalLine[] => {
+    const hint = isMobile
+      ? 'Tap <span style="color: var(--terminal-primary)">≡</span> to explore commands.'
+      : 'Type <span style="color: var(--terminal-primary)">\'help\'</span> or press <span style="color: var(--terminal-primary)">Tab</span> to explore.';
+    return [
+      { content: `<span style="color: var(--terminal-gray)">${hint}</span>`, type: 'output' as const, isHtml: true },
+    ];
+  };
+```
+
+Key details:
+- Uses `isMobile` (already in scope from line 42) to select the variant
+- Wraps content in `<span>` with `--terminal-gray` for muted rendering
+- Highlights keywords (`'help'`, `Tab`, `≡`) in `--terminal-primary`
+- Uses `isHtml: true` so the span renders via DOMPurify (line 641-646)
+- `style` attribute is allowed by `PURIFY_CONFIG` (`ADD_ATTR: ['style']` on line 16)
+
+- [ ] **Step 2: Update mount effect**
+
+Change line 508 from:
+```tsx
+    setTerminalOutput(displayHelp());
+```
+to:
+```tsx
+    setTerminalOutput(displayMotd());
+```
+
+- [ ] **Step 3: Update `clear` handler**
+
+Change line 191 from:
+```tsx
+      setTerminalOutput(displayHelp());
+```
+to:
+```tsx
+      setTerminalOutput(displayMotd());
+```
+
+Note: `Ctrl+L` (line 501-504) calls `handleCommand('clear')`, which hits this handler. No separate update needed.
+
+- [ ] **Step 4: Remove input placeholder**
+
+Remove the `placeholder` attribute from line 686. Change from:
+```tsx
+              placeholder={isMobile ? "Tap Cmds for suggestions..." : "Type a command or press Tab for suggestions..."}
+```
+to: (delete the entire line)
+
+The MOTD hint line now serves this purpose.
+
+- [ ] **Step 5: Verify build compiles**
+
+Run: `npx tsc --noEmit`
+Expected: No errors
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/components/Terminal/Terminal.tsx
+git commit -m "feat: replace help auto-display with minimal MOTD hint"
+```
+
+---
+
+### Task 3: Add `help` command handler
+
+**Files:**
+- Modify: `src/components/Terminal/Terminal.tsx` (insert before the `clear` early-return handler)
+
+Note: Line numbers below reference the original file. After Task 2's insertions, they will have shifted by ~7 lines. Use the descriptive anchors (e.g., "before the `if (trimmedCmd === 'clear')` block") to find the correct insertion point.
+
+- [ ] **Step 1: Add early-return `help` handler**
+
+Insert immediately before the `if (trimmedCmd === 'clear')` block:
+
+```tsx
+    if (trimmedCmd === 'help') {
+      setTerminalOutput(prev => [...prev, ...displayHelp()]);
+      setCommandHistory(prev => [...prev, trimmedCmd].slice(-MAX_HISTORY));
+      setHistoryIndex(-1);
+      setInputCommand('');
+      setAutoSuggestion(null);
+      return;
+    }
+```
+
+Key details:
+- **Appends** to output (unlike `clear` which replaces) — `displayHelp()` already includes the `~ $ help` input line as its first entry, so no separate input line is added
+- Adds to `commandHistory` so it appears when pressing ↑ (unlike `clear`/`exit` which don't)
+- Instant display — no spinner, no setTimeout (same pattern as `clear` and `exit`)
+- Resets `historyIndex`, `inputCommand`, and `autoSuggestion` (standard cleanup)
+
+- [ ] **Step 2: Verify build compiles**
+
+Run: `npx tsc --noEmit`
+Expected: No errors
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add src/components/Terminal/Terminal.tsx
+git commit -m "feat: add help as a user-typeable command"
+```
+
+---
+
+## Chunk 2: Tests
+
+### Task 4: Update existing tests and add new test
+
+**Files:**
+- Modify: `src/components/Terminal/__tests__/Terminal.test.tsx:41-44, 81-91`
+
+- [ ] **Step 1: Write failing test for `help` command**
+
+Add a new test case after the existing `'clears terminal and shows help on clear command'` test (after line 91):
+
+```tsx
+  it('shows full help output when help command is typed', () => {
+    renderWithProviders(<Terminal {...defaultProps} />);
+    submitCommand('help');
+    expect(screen.getByText('Available commands:')).toBeInTheDocument();
+  });
+```
+
+Note: `help` is an early-return command (no spinner), so no `advanceTimersByTime` is needed.
+
+- [ ] **Step 2: Run test to verify it passes**
+
+Run: `npx vitest run src/components/Terminal/__tests__/Terminal.test.tsx --reporter=verbose`
+Expected: The new test PASSES (since the `help` handler was already added in Task 3). If it fails, the handler wasn't added correctly — check Task 3.
+
+- [ ] **Step 3: Update mount test assertion**
+
+Change the test at line 41-44 from:
+```tsx
+  it('renders help screen on mount', () => {
+    renderWithProviders(<Terminal {...defaultProps} />);
+    expect(screen.getByText('Available commands:')).toBeInTheDocument();
+  });
+```
+to:
+```tsx
+  it('renders MOTD hint on mount', () => {
+    renderWithProviders(<Terminal {...defaultProps} />);
+    expect(screen.getByText(/Type.*'help'.*or press.*Tab.*to explore/)).toBeInTheDocument();
+  });
+```
+
+Uses regex because the content is HTML with `<span>` tags — `getByText` matches on rendered text content.
+
+- [ ] **Step 4: Update clear test assertion**
+
+Change the test at line 81-91 from:
+```tsx
+  it('clears terminal and shows help on clear command', () => {
+    renderWithProviders(<Terminal {...defaultProps} />);
+    submitCommand('history');
+    act(() => { vi.advanceTimersByTime(600); });
+    expect(screen.getByText(/Still shipping/)).toBeInTheDocument();
+
+    // Clear — synchronous, no timer needed
+    submitCommand('clear');
+    expect(screen.queryByText(/Still shipping/)).not.toBeInTheDocument();
+    expect(screen.getByText('Available commands:')).toBeInTheDocument();
+  });
+```
+to:
+```tsx
+  it('clears terminal and shows MOTD on clear command', () => {
+    renderWithProviders(<Terminal {...defaultProps} />);
+    submitCommand('history');
+    act(() => { vi.advanceTimersByTime(600); });
+    expect(screen.getByText(/Still shipping/)).toBeInTheDocument();
+
+    // Clear — synchronous, no timer needed
+    submitCommand('clear');
+    expect(screen.queryByText(/Still shipping/)).not.toBeInTheDocument();
+    expect(screen.getByText(/Type.*'help'.*or press.*Tab.*to explore/)).toBeInTheDocument();
+  });
+```
+
+- [ ] **Step 5: Run all Terminal tests**
+
+Run: `npx vitest run src/components/Terminal/__tests__/Terminal.test.tsx --reporter=verbose`
+Expected: All tests pass
+
+- [ ] **Step 6: Run full test suite**
+
+Run: `npx vitest run --reporter=verbose`
+Expected: All tests pass. No regressions in other test files.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add src/components/Terminal/__tests__/Terminal.test.tsx
+git commit -m "test: update Terminal tests for MOTD and help command"
+```
+
+---
+
+## Chunk 3: Manual Verification
+
+### Task 5: Manual smoke test
+
+- [ ] **Step 1: Start dev server**
+
+Run: `npm run dev`
+
+- [ ] **Step 2: Verify desktop behavior**
+
+Open browser to dev server URL:
+1. Page loads → single hint line `Type 'help' or press Tab to explore.` in gray + prompt. No 17-line help dump.
+2. Input field has no placeholder text.
+3. Type `help` → full command listing appears with all 11 commands (including help itself) + tips section.
+4. Type `clear` → resets to hint line.
+5. Press `Ctrl+L` → same as clear.
+6. Press Tab → suggestions dropdown shows `help` in the list.
+7. Type `hel` → auto-suggestion ghost text shows `help`.
+
+- [ ] **Step 3: Verify mobile behavior**
+
+Use browser DevTools responsive mode (width < 768px):
+1. Page loads → hint shows `Tap ≡ to explore commands.` instead of the desktop variant.
+2. Tap `≡ Cmds` button → suggestions dropdown works.
+
+- [ ] **Step 4: Stop dev server**

--- a/docs/superpowers/plans/2026-03-20-motd-typing-animation.md
+++ b/docs/superpowers/plans/2026-03-20-motd-typing-animation.md
@@ -1,0 +1,403 @@
+# MOTD Typing Animation Implementation Plan
+
+> **For agentic workers:** REQUIRED: Use superpowers:subagent-driven-development (if subagents available) or superpowers:executing-plans to implement this plan. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add a character-by-character typing animation to the MOTD hint line after the boot splash completes, making the terminal feel alive.
+
+**Architecture:** Pass a `bootComplete` prop from App.tsx to Terminal. A new `useEffect` watching `bootComplete` drives a 300ms delay → setInterval typing animation. Timer refs enable cleanup on unmount/clear/early-completion. User interaction during animation snaps to final state.
+
+**Tech Stack:** React 19, TypeScript, Vitest, @testing-library/react
+
+**Spec:** `docs/superpowers/specs/2026-03-19-motd-typing-animation-design.md`
+
+---
+
+## Chunk 1: Wire `bootComplete` prop from App to Terminal
+
+### Task 1: Add `bootComplete` prop to TerminalProps and pass from App.tsx
+
+**Files:**
+- Modify: `src/components/Terminal/Terminal.tsx:31-39` (TerminalProps type), `Terminal.tsx:41` (component signature)
+- Modify: `src/App.tsx:255-264` (Terminal JSX)
+
+- [ ] **Step 1: Add `bootComplete` to TerminalProps type**
+
+In `src/components/Terminal/Terminal.tsx`, add `bootComplete?: boolean` to the `TerminalProps` type at line 31-39:
+
+```tsx
+type TerminalProps = {
+  onShutdown?: () => void;
+  onBell?: () => void;
+  playSound?: (sound: SoundType) => void;
+  soundEnabled?: boolean;
+  onSoundSet?: (enabled: boolean) => void;
+  onRevealStateChange?: (isRevealing: boolean) => void;
+  bootComplete?: boolean;
+  ref?: Ref<TerminalHandle>;
+};
+```
+
+- [ ] **Step 2: Destructure `bootComplete` in component signature**
+
+Update line 41 to include `bootComplete`:
+
+```tsx
+const Terminal = ({ onShutdown, onBell, playSound, soundEnabled, onSoundSet, onRevealStateChange, bootComplete, ref }: TerminalProps) => {
+```
+
+- [ ] **Step 3: Pass `bootComplete` from App.tsx**
+
+In `src/App.tsx`, add `bootComplete={!showBootSplash}` to the Terminal component at line 255:
+
+```tsx
+              <Terminal
+                key={sessionKey}
+                ref={terminalRef}
+                onShutdown={handleShutdown}
+                onBell={handleBell}
+                playSound={sound.play}
+                soundEnabled={sound.enabled}
+                onSoundSet={sound.setEnabled}
+                onRevealStateChange={setIsRevealing}
+                bootComplete={!showBootSplash}
+              />
+```
+
+- [ ] **Step 4: Verify build compiles**
+
+Run: `npx tsc --noEmit`
+Expected: No errors
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/components/Terminal/Terminal.tsx src/App.tsx
+git commit -m "feat: pass bootComplete prop from App to Terminal"
+```
+
+---
+
+## Chunk 2: Animation logic in Terminal.tsx
+
+### Task 2: Add animation timer refs and state
+
+**Files:**
+- Modify: `src/components/Terminal/Terminal.tsx:57-68` (refs section)
+
+- [ ] **Step 1: Add MOTD animation refs**
+
+After `spinnerIdRef` (line 58), add three refs:
+
+```tsx
+  const motdDelayRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const motdIntervalRef = useRef<ReturnType<typeof setInterval> | null>(null);
+  const motdAnimatingRef = useRef(false);
+```
+
+- `motdDelayRef` — the 300ms setTimeout ID
+- `motdIntervalRef` — the setInterval ID
+- `motdAnimatingRef` — whether animation is in progress (for early completion checks)
+
+- [ ] **Step 2: Verify build compiles**
+
+Run: `npx tsc --noEmit`
+Expected: No errors
+
+---
+
+### Task 3: Change mount effect to set empty output
+
+**Files:**
+- Modify: `src/components/Terminal/Terminal.tsx:525-526` (mount effect)
+
+- [ ] **Step 1: Replace `displayMotd()` with empty output in mount effect**
+
+Change line 526 from:
+```tsx
+    setTerminalOutput(displayMotd());
+```
+to:
+```tsx
+    setTerminalOutput([{ content: '', type: 'output' }]);
+```
+
+The MOTD content will now be set by the animation effect (Task 4) when `bootComplete` transitions to `true`.
+
+- [ ] **Step 2: Verify build compiles**
+
+Run: `npx tsc --noEmit`
+Expected: No errors
+
+---
+
+### Task 4: Add animation effect
+
+**Files:**
+- Modify: `src/components/Terminal/Terminal.tsx` (insert new useEffect after the mount effect, before the scroll effect)
+
+- [ ] **Step 1: Add the animation useEffect**
+
+Insert a new `useEffect` after the mount effect's closing `}, []);` (after line 547) and before the scroll effect (line 549):
+
+```tsx
+  // MOTD typing animation — triggered when boot splash completes
+  useEffect(() => {
+    if (!bootComplete) return;
+
+    // Reduced motion or no bootComplete prop: show MOTD instantly
+    if (reducedMotion) {
+      setTerminalOutput(displayMotd());
+      return;
+    }
+
+    const plainText = isMobile
+      ? 'Tap \u2261 to explore commands.'
+      : "Type 'help' or press Tab to explore.";
+
+    motdAnimatingRef.current = true;
+    setTerminalOutput([{ content: '', type: 'output' }]);
+
+    let charIndex = 0;
+
+    motdDelayRef.current = setTimeout(() => {
+      motdDelayRef.current = null;
+
+      motdIntervalRef.current = setInterval(() => {
+        if (!motdAnimatingRef.current || charIndex >= plainText.length) {
+          if (motdIntervalRef.current) clearInterval(motdIntervalRef.current);
+          motdIntervalRef.current = null;
+          motdAnimatingRef.current = false;
+          setTerminalOutput(displayMotd());
+          return;
+        }
+        charIndex++;
+        setTerminalOutput([{ content: plainText.slice(0, charIndex), type: 'output' }]);
+      }, 30);
+    }, 300);
+
+    return () => {
+      if (motdDelayRef.current) { clearTimeout(motdDelayRef.current); motdDelayRef.current = null; }
+      if (motdIntervalRef.current) { clearInterval(motdIntervalRef.current); motdIntervalRef.current = null; }
+      motdAnimatingRef.current = false;
+    };
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [bootComplete]);
+```
+
+Key details:
+- Watches `bootComplete` — fires when boot splash completes or on remount after session restart
+- 300ms delay lets the CSS opacity fade-in settle before typing starts
+- 30ms per character for consistent pacing (~1.1s for 37-char desktop text)
+- On completion, swaps plain text for the final HTML version with `--terminal-primary` highlights
+- Cleanup clears both timers on unmount
+- `displayMotd` and `isMobile` are stable across the animation's lifetime (mount-only values), so the eslint disable is safe
+- `reducedMotion` path sets `displayMotd()` immediately — tests use `prefers-reduced-motion: true` by default
+
+- [ ] **Step 2: Verify build compiles**
+
+Run: `npx tsc --noEmit`
+Expected: No errors
+
+---
+
+### Task 5: Add early completion to user interaction handlers
+
+**Files:**
+- Modify: `src/components/Terminal/Terminal.tsx:179-191` (handleInputChange), `Terminal.tsx:419-431` (actionTab), `Terminal.tsx:193-213` (handleCommand — clear handler)
+
+- [ ] **Step 1: Add early completion to `handleInputChange`**
+
+In `handleInputChange` (line 179), add a check at the top of the function, after the `isInputBlocked` guard and before the `pendingExecuteRef` check:
+
+```tsx
+  const handleInputChange = (e: ChangeEvent<HTMLInputElement>) => {
+    if (isInputBlocked) return;
+    if (motdAnimatingRef.current) {
+      motdAnimatingRef.current = false;
+      if (motdDelayRef.current) { clearTimeout(motdDelayRef.current); motdDelayRef.current = null; }
+      if (motdIntervalRef.current) { clearInterval(motdIntervalRef.current); motdIntervalRef.current = null; }
+      setTerminalOutput(displayMotd());
+    }
+    if (pendingExecuteRef.current) {
+```
+
+- [ ] **Step 2: Add early completion to `actionTab`**
+
+In `actionTab` (line 419), add a check at the top of the function:
+
+```tsx
+  const actionTab = () => {
+    if (motdAnimatingRef.current) {
+      motdAnimatingRef.current = false;
+      if (motdDelayRef.current) { clearTimeout(motdDelayRef.current); motdDelayRef.current = null; }
+      if (motdIntervalRef.current) { clearInterval(motdIntervalRef.current); motdIntervalRef.current = null; }
+      setTerminalOutput(displayMotd());
+    }
+    if (showSuggestions) {
+```
+
+- [ ] **Step 3: Add early completion to `handleCommand`**
+
+In `handleCommand` (line 193), add a check after the `isInputBlocked` guard and before `trimmedCmd === ''`:
+
+```tsx
+  const handleCommand = (cmd: string) => {
+    if (isInputBlocked) return;
+    if (motdAnimatingRef.current) {
+      motdAnimatingRef.current = false;
+      if (motdDelayRef.current) { clearTimeout(motdDelayRef.current); motdDelayRef.current = null; }
+      if (motdIntervalRef.current) { clearInterval(motdIntervalRef.current); motdIntervalRef.current = null; }
+      setTerminalOutput(displayMotd());
+    }
+    const trimmedCmd = cmd.trim().toLowerCase();
+```
+
+Note: The `clear` handler (line 208) doesn't need a separate check — the early completion block above runs first, canceling the animation. Then `clear` overwrites with `displayMotd()` as usual.
+
+- [ ] **Step 4: Add timer cleanup to existing cleanup effect**
+
+Update the cleanup effect (line 571-579) to also clear MOTD animation timers:
+
+```tsx
+  useEffect(() => {
+    const timeouts = spinnerTimeouts.current;
+    return () => {
+      timeouts.forEach(clearTimeout);
+      timeouts.clear();
+      if (pendingExecuteRef.current) clearTimeout(pendingExecuteRef.current);
+      if (motdDelayRef.current) clearTimeout(motdDelayRef.current);
+      if (motdIntervalRef.current) clearInterval(motdIntervalRef.current);
+      cancelAnimationFrame(revealRafRef.current);
+    };
+  }, []);
+```
+
+- [ ] **Step 5: Verify build compiles**
+
+Run: `npx tsc --noEmit`
+Expected: No errors
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/components/Terminal/Terminal.tsx
+git commit -m "feat: add MOTD typing animation with early completion"
+```
+
+---
+
+## Chunk 3: Tests
+
+### Task 6: Update existing tests and add new test
+
+**Files:**
+- Modify: `src/components/Terminal/__tests__/Terminal.test.tsx:15-22` (defaultProps), `Terminal.test.tsx:41-46` (mount test), `Terminal.test.tsx:83-95` (clear test)
+
+- [ ] **Step 1: Add `bootComplete: true` to defaultProps**
+
+In `Terminal.test.tsx`, update defaultProps (line 15-22) to include `bootComplete: true`:
+
+```tsx
+const defaultProps = {
+  onShutdown: vi.fn(),
+  onBell: vi.fn(),
+  playSound: vi.fn(),
+  soundEnabled: false,
+  onSoundSet: vi.fn(),
+  onRevealStateChange: vi.fn(),
+  bootComplete: true,
+};
+```
+
+This is critical: the test setup already uses `prefers-reduced-motion: true` (via `setupTerminalMedia`), which means `reducedMotion` is true and the animation is skipped. With `bootComplete: true`, the animation effect fires but takes the instant `reducedMotion` path, setting `displayMotd()` immediately. **Existing assertions still pass.**
+
+- [ ] **Step 2: Run existing tests to verify they still pass**
+
+Run: `npx vitest run src/components/Terminal/__tests__/Terminal.test.tsx --reporter=verbose`
+Expected: All 9 existing tests pass
+
+- [ ] **Step 3: Add early completion test**
+
+Add a new test after the `'shows full help output when help command is typed'` test (after line 101):
+
+```tsx
+  it('snaps MOTD to final state on early user input', () => {
+    // Override reduced-motion to false so animation would normally play
+    mockMatchMedia(query => query === '(min-width: 768px)');
+    renderWithProviders(<Terminal {...defaultProps} />);
+    // Advance past the 300ms delay to start the animation
+    act(() => { vi.advanceTimersByTime(350); });
+    // User starts typing — animation should snap to final state
+    const input = screen.getByRole('textbox');
+    fireEvent.change(input, { target: { value: 'h' } });
+    expect(screen.getAllByText((_, el) =>
+      el?.tagName === 'SPAN' && /Type.*'help'.*Tab.*explore/.test(el.textContent ?? '')
+    ).length).toBeGreaterThan(0);
+  });
+```
+
+Key details:
+- Overrides `prefers-reduced-motion` to false (so the animation actually starts)
+- Sets `bootComplete: true` via defaultProps (animation triggers immediately)
+- Advances timers past the 300ms delay so the typing interval has started
+- Fires a change event on the input — this triggers `handleInputChange` which calls the early completion
+- Asserts the final HTML MOTD is present (not the plain-text partial)
+
+- [ ] **Step 4: Run all Terminal tests**
+
+Run: `npx vitest run src/components/Terminal/__tests__/Terminal.test.tsx --reporter=verbose`
+Expected: All 10 tests pass (9 existing + 1 new)
+
+- [ ] **Step 5: Run full test suite**
+
+Run: `npx vitest run --reporter=verbose`
+Expected: All tests pass. No regressions.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/components/Terminal/__tests__/Terminal.test.tsx
+git commit -m "test: add bootComplete prop to Terminal tests and early completion test"
+```
+
+---
+
+## Chunk 4: Manual Verification
+
+### Task 7: Manual smoke test
+
+- [ ] **Step 1: Start dev server**
+
+Run: `npm run dev`
+
+- [ ] **Step 2: Verify typing animation on load**
+
+Open browser to dev server URL:
+1. Boot splash plays → terminal fades in → after ~300ms, MOTD types out character by character (~1.1s)
+2. On completion, text shows highlighted keywords (`'help'`, `Tab`) in `--terminal-primary` color
+
+- [ ] **Step 3: Verify early completion**
+
+Reload page. During the MOTD typing animation, start typing any command. The MOTD should snap to its final HTML state immediately.
+
+- [ ] **Step 4: Verify `clear` shows instant MOTD**
+
+Type `clear` — MOTD appears instantly (no typing animation).
+
+- [ ] **Step 5: Verify `clear` during animation**
+
+Reload page. During the MOTD typing animation, type `clear` quickly. Animation should stop, and the instant MOTD should appear.
+
+- [ ] **Step 6: Verify reduced-motion**
+
+In browser DevTools, enable `prefers-reduced-motion: reduce`. Reload — MOTD should appear instantly on load (no animation).
+
+- [ ] **Step 7: Verify session restart**
+
+Type `exit`, wait for shutdown sequence, press any key. Boot splash replays, then MOTD types out again.
+
+- [ ] **Step 8: Verify mobile behavior**
+
+Use browser DevTools responsive mode (width < 768px). Reload — hint shows `Tap ≡ to explore commands.` typing out character by character.
+
+- [ ] **Step 9: Stop dev server**

--- a/docs/superpowers/specs/2026-03-19-minimal-motd-design.md
+++ b/docs/superpowers/specs/2026-03-19-minimal-motd-design.md
@@ -1,0 +1,125 @@
+# Minimal MOTD: Replace Auto-Displayed Help with One-Line Hint
+
+## Problem
+
+The terminal auto-displays the full `help` output (17 lines) on initial load and after every `clear` command. This consumes excessive screen real estate and violates UNIX philosophy, where login messages communicate identity/status — not usage manuals. Help should be pull-based (user requests it), not push-based (forced on every load).
+
+Additionally, `help` is not currently a user-typeable command — `displayHelp()` is only called internally by the mount effect and the `clear` handler. Typing `help` today produces "Command not found."
+
+## Design
+
+### Core Change
+
+1. Replace `displayHelp()` call sites (mount + clear) with a new `displayMotd()` that renders a single hint line
+2. Add `help` as a real command that users can type to see the full listing
+3. Remove input placeholder text (redundant with the MOTD hint)
+
+### Desktop
+
+```
+Type 'help' or press Tab to explore.
+
+~ $
+```
+
+One line of muted output (`--terminal-gray` color), followed by the prompt.
+
+### Mobile
+
+```
+Tap ≡ to explore commands.
+
+~ $
+```
+
+Mobile variant uses the existing `isMobile` prop. The hint references the `≡ Cmds` toolbar button, which is the primary discovery mechanism on mobile (keyboard is disabled via `inputMode="none"`).
+
+### Behavior Changes
+
+| Scenario | Before | After |
+|----------|--------|-------|
+| Initial load | 17-line help output | 1-line hint |
+| `clear` command | Resets to 17-line help | Resets to 1-line hint |
+| `Ctrl+L` shortcut | Resets to 17-line help (delegates to `clear` handler) | Resets to 1-line hint |
+| Typing `help` | "Command not found: help" | Full 17-line listing (new command) |
+| Tab / suggestions | Dropdown appears | Unchanged |
+| Auto-suggestions | Ghost text while typing | Unchanged |
+| Input placeholder | `"Type a command or press Tab for suggestions..."` | Removed (MOTD hint covers it) |
+| Session restart (`key={sessionKey}` remount) | Mount effect shows 17-line help | Mount effect shows 1-line hint |
+
+### What Does NOT Change
+
+- Tab autocomplete and suggestions dropdown behavior
+- Auto-suggestion ghost text
+- Progressive output reveal system
+- Mobile toolbar behavior
+- `displaySuggestions` useMemo pattern
+- `helpEntry` type on `TerminalLine` and its rendering path (lines 634-640) — still used by the `help` command output
+
+## Implementation
+
+### Files Modified
+
+- **`src/components/Terminal/Terminal.tsx`** — main changes
+- **`src/components/Terminal/__tests__/Terminal.test.tsx`** — test updates
+
+### Steps
+
+1. **Add `displayMotd()` function** — returns a single `TerminalLine` array with the hint:
+   - Desktop: `Type 'help' or press Tab to explore.`
+   - Mobile: `Tap ≡ to explore commands.`
+   - Use `isMobile` prop to select variant
+   - The line is a standard `type: 'output'` with `isHtml: true`, content wrapped in a `<span style="color: var(--terminal-gray)">` for muted rendering
+   - No `input`-type line, no timestamp — the hint is pure output, not a simulated command execution
+   - Since it's a single line, progressive reveal renders it instantly (existing behavior)
+
+2. **Keep `displayHelp()` as-is** — it continues to produce the full 17-line listing with `helpEntry` items, used only by the new `help` command handler
+
+3. **Update mount effect** (line 508) — change `displayHelp()` to `displayMotd()`
+
+4. **Update `clear` handler** (line 191) — change `displayHelp()` to `displayMotd()`. The `Ctrl+L` handler (line 501-504) delegates to `handleCommand('clear')`, so no separate update is needed.
+
+5. **Add `help` command handler** — add an early-return case in `handleCommand` (alongside `clear`, `exit`, etc.) that appends `displayHelp()` output to the terminal. This makes `help` a real user-typeable command. Note: `displayHelp()` already includes `~ $ help` as its first entry (the input line), so the handler should append its output directly without adding a separate input line. Also add `help` to command history so it appears when pressing ↑ (unlike `clear`/`exit`, `help` is informational, not a terminal control command).
+
+6. **Remove input placeholder** (line 686) — delete the `placeholder` attribute from the input element. The MOTD hint line now serves this purpose, and having both is redundant.
+
+7. **Update `suggestions` array** — add a `help` entry to the suggestions array in `commands.tsx` so it appears in Tab-completion and the suggestions dropdown. Use an appropriate icon (e.g., `HelpCircle` from lucide-react).
+
+### Note on `help` command placement
+
+Add `help` as an early-return command in `handleCommand` (like `clear` and `exit`), not in the `commands` map. The `commands` map is for commands that show a spinner before output. `help` should display instantly, like `clear`.
+
+## Testing
+
+### Manual Verification
+
+1. Load the page — should see only the hint line + prompt, no placeholder in input
+2. Type `help` — full command listing appears (was previously "Command not found")
+3. Type `clear` — resets to hint line, not to help output
+4. Press `Ctrl+L` — same as clear
+5. Resize to mobile — hint changes to "Tap ≡ to explore commands."
+6. Use mobile toolbar `≡ Cmds` button — suggestions dropdown works normally
+7. Trigger session restart — remount shows hint line, not help output
+8. Tab-complete `hel` — should suggest `help`
+
+### Existing Tests to Update
+
+Two tests in `src/components/Terminal/__tests__/Terminal.test.tsx` will break:
+
+- **`renders help screen on mount`** (approx line 41-44) — currently asserts `screen.getByText('Available commands:')`. Update to assert the MOTD hint text instead.
+- **`clears terminal and shows help on clear command`** (approx line 81-91) — currently asserts `screen.getByText('Available commands:')` after clear. Update to assert the MOTD hint text instead.
+
+Add new test:
+- **`shows full help output when help command is typed`** — type `help`, assert `screen.getByText('Available commands:')` appears.
+
+## Design Decisions
+
+**Why not placeholder text in the input field?** The input already had placeholder text (`"Type a command or press Tab for suggestions..."`), but placeholder text is a web form pattern, not a terminal pattern. The MOTD hint line as terminal output is more authentic to the CRT aesthetic. Having both the MOTD hint and a placeholder would be redundant, so the placeholder is removed.
+
+**Why not differentiate first-visit vs. returning visitors?** Adds localStorage state tracking complexity for marginal UX benefit. Same experience every time is simpler and more predictable — consistent with how real terminals behave.
+
+**Why not show personal details in the MOTD?** The sidebar already displays name, role, and social links. Duplicating this in the terminal output is redundant.
+
+**Why a mobile-specific hint?** On mobile, Tab doesn't exist and typing is disabled. The `≡ Cmds` toolbar button is the actual discovery mechanism, so the hint should point to it.
+
+**Why add `help` as a command?** The MOTD says "Type 'help'" — this creates a user expectation that `help` works. Previously, `displayHelp()` was only called internally and typing `help` gave "Command not found." Adding it as an early-return command (no spinner, instant display) is consistent with how `clear` works.

--- a/docs/superpowers/specs/2026-03-19-motd-typing-animation-design.md
+++ b/docs/superpowers/specs/2026-03-19-motd-typing-animation-design.md
@@ -1,0 +1,159 @@
+# MOTD Typing Animation
+
+Addendum to `2026-03-19-minimal-motd-design.md`.
+
+## Problem
+
+After the boot splash fade-in, the MOTD hint line appears instantly — a jarring cut from the animated boot sequence to a static text line. A typing animation bridges this transition, making the terminal feel alive.
+
+## Design
+
+### Behavior
+
+After the boot splash completes and the terminal fades in, the MOTD hint types out character by character:
+
+1. **Boot splash completes** → Terminal becomes visible (0.3s CSS opacity fade-in)
+2. **300ms delay** after visibility (lets fade-in settle)
+3. **~30ms per character** reveals the plain-text hint progressively
+4. On completion, the line swaps to the final HTML version (with `--terminal-primary` highlights on `'help'`, `Tab`, or `≡`)
+
+Total duration: ~300ms delay + ~1.1s typing = ~1.4s after terminal becomes visible.
+
+### When It Plays
+
+| Scenario | Animation? | Why |
+|----------|-----------|-----|
+| Initial page load | Yes | Boot splash completes → animation starts |
+| Session restart (`key={sessionKey}` remount) | Yes | Boot splash replays, terminal remounts, `bootComplete` re-triggers |
+| After `clear` | No — instant display | User is actively working, no boot transition |
+| After `Ctrl+L` | No — delegates to `clear` | Same as clear |
+| `prefers-reduced-motion` | No — instant display | Accessibility |
+
+### Edge Cases
+
+**User types during animation:** The animation completes instantly (jumps to final state). Input is not blocked — the existing `isInputBlocked` (derived from `revealingLines`) is not used for MOTD animation. If the user starts typing, presses Tab, or executes any command, the MOTD snaps to its final HTML version immediately.
+
+**`clear` during animation:** The `clear` handler cancels any running MOTD animation (clears timers via refs) before setting terminal output to the instant MOTD. This prevents stale animation ticks from overwriting the cleared state.
+
+**Mobile:** Same animation, different text (`Tap ≡ to explore commands.` instead of desktop variant). The `isMobile` check happens before the animation starts.
+
+## Implementation
+
+### Files Modified
+
+- **`src/App.tsx`** — pass `bootComplete` prop to Terminal
+- **`src/components/Terminal/Terminal.tsx`** — animation logic
+
+### Triggering the Animation: `bootComplete` Prop
+
+The terminal mounts hidden behind `opacity: 0` while the boot splash plays. The mount effect fires immediately, but the terminal isn't visible yet. Starting the animation on mount means it runs invisibly and finishes before the user ever sees it.
+
+**Fix:** Add a `bootComplete` prop to Terminal, passed from App.tsx as `!showBootSplash`. The animation is triggered by a `useEffect` watching this prop, not by the mount effect.
+
+Flow:
+1. App renders with `showBootSplash = true` → Terminal mounts with `bootComplete = false`
+2. Boot splash plays its BIOS animation (several seconds)
+3. `handleBootComplete` runs → `setShowBootSplash(false)` → Terminal's `bootComplete` prop becomes `true`
+4. Terminal fades in (0.3s CSS opacity transition)
+5. `useEffect` on `bootComplete` fires → 300ms delay → typing animation starts
+6. Animation completes → plain text swaps to final HTML
+
+On session restart: `handleRestart` sets `showBootSplash = true` and increments `sessionKey`. Terminal remounts with `bootComplete = false`. When boot splash replays and completes, `bootComplete` becomes `true` again, triggering the animation.
+
+### Mount Effect Change
+
+The existing mount effect (line 525-529) currently calls `setTerminalOutput(displayMotd())`. Change this to set **empty output** (or a blank placeholder line) instead. The MOTD content will be set by either:
+- The animation effect (when `bootComplete` transitions to `true` and `reducedMotion` is false)
+- Instantly (when `reducedMotion` is true — the animation effect sets `displayMotd()` immediately)
+
+### Animation Effect
+
+New `useEffect` that watches `bootComplete`:
+
+```
+useEffect:
+  deps: [bootComplete]
+  if (!bootComplete) return
+  if (reducedMotion) { setTerminalOutput(displayMotd()); return }
+
+  // Start with empty output
+  setTerminalOutput([{ content: '', type: 'output' }])
+
+  // 300ms delay for fade-in to complete
+  delayTimer = setTimeout(() => {
+    charIndex = 0
+    typingTimer = setInterval(() => {
+      if (earlyCompleteRef.current || charIndex >= plainText.length) {
+        clearInterval(typingTimer)
+        setTerminalOutput(displayMotd())  // swap to final HTML
+        return
+      }
+      charIndex++
+      setTerminalOutput([{ content: plainText.slice(0, charIndex), type: 'output' }])
+    }, 30)
+  }, 300)
+
+  return () => { clearTimeout(delayTimer); clearInterval(typingTimer) }
+```
+
+### Early Completion
+
+Add a `motdAnimatingRef` ref (tracks whether animation is in progress) and use the existing flow:
+
+- `handleInputChange`, `actionTab`, `handleCommand` — if `motdAnimatingRef.current` is true, set `earlyCompleteRef.current = true` (the next animation tick jumps to final state)
+- `clear` handler — if `motdAnimatingRef.current` is true, clear timers directly (via refs), set terminal output to `displayMotd()`, and set `motdAnimatingRef.current = false`
+
+### Animation Timer Refs
+
+Store timer IDs in refs for cleanup:
+- `motdDelayRef` — the 300ms `setTimeout` ID
+- `motdIntervalRef` — the `setInterval` ID
+
+These are cleared on: unmount, early completion, `clear` during animation.
+
+### Plain-Text Hints
+
+The typing animation needs plain-text versions of the hints (no HTML spans):
+
+- Desktop: `Type 'help' or press Tab to explore.`
+- Mobile: `Tap ≡ to explore commands.`
+
+Define as simple string constants computed from `isMobile`.
+
+### TerminalProps Change
+
+Add `bootComplete?: boolean` to the `TerminalProps` type.
+
+## Testing
+
+### Existing Tests
+
+The mount test (`'renders MOTD hint on mount'`) uses `prefers-reduced-motion: true` in the test setup (via `setupTerminalMedia`), which means `reducedMotion` is true and the animation is skipped. The `bootComplete` prop must be passed as `true` in test `defaultProps` so the MOTD renders immediately. **Existing assertions still pass** after this prop addition.
+
+### New Test
+
+Add one test for early completion:
+- Render Terminal with `bootComplete={true}` and `prefers-reduced-motion: false`
+- Immediately type a command
+- Assert MOTD snaps to final state (full hint text present)
+
+### Manual Verification
+
+1. Load page — after boot splash fades in, MOTD types out character by character (~1.4s)
+2. Load page, immediately start typing — MOTD snaps to final state
+3. Type `clear` — MOTD appears instantly (no typing animation)
+4. Type `clear` during MOTD animation — animation stops, instant MOTD displayed
+5. Enable `prefers-reduced-motion` in browser — MOTD appears instantly on load
+6. Trigger session restart — boot splash replays, then MOTD types out again
+
+## Design Decisions
+
+**Why a `bootComplete` prop instead of mounting later?** The terminal needs to be in the DOM before the boot splash finishes (for focus management, key listeners, etc.). Deferring mount would break existing patterns. A prop is the minimal interface change.
+
+**Why plain text during animation?** The HTML version has `<span>` tags with inline styles. Revealing character by character would show raw HTML fragments mid-type (e.g., `Type <sp`). Plain text during reveal, HTML swap at the end.
+
+**Why not animate after `clear`?** The user is actively working — re-typing the MOTD every time they clear would feel like lag, not atmosphere. The animation is a first-impression flourish.
+
+**Why 300ms delay before typing starts?** The boot splash fades out via a 0.3s CSS opacity transition. The delay lets the terminal fully appear before typing begins.
+
+**Why `setInterval` over `requestAnimationFrame`?** The existing progressive reveal uses RAF for multi-line output, but that system is tightly coupled to the `revealingLines`/`revealedCount` state machine. The MOTD typing is a simpler, independent animation that doesn't need RAF's frame-syncing — a fixed 30ms interval produces consistent character pacing. Keeping it separate avoids coupling two unrelated animation systems.

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -261,6 +261,7 @@ const App = () => {
                 soundEnabled={sound.enabled}
                 onSoundSet={sound.setEnabled}
                 onRevealStateChange={setIsRevealing}
+                bootComplete={!showBootSplash}
               />
             </TerminalWindow>
           </main>

--- a/src/components/Terminal/Terminal.tsx
+++ b/src/components/Terminal/Terminal.tsx
@@ -35,10 +35,11 @@ type TerminalProps = {
   soundEnabled?: boolean;
   onSoundSet?: (enabled: boolean) => void;
   onRevealStateChange?: (isRevealing: boolean) => void;
+  bootComplete?: boolean;
   ref?: Ref<TerminalHandle>;
 };
 
-const Terminal = ({ onShutdown, onBell, playSound, soundEnabled, onSoundSet, onRevealStateChange, ref }: TerminalProps) => {
+const Terminal = ({ onShutdown, onBell, playSound, soundEnabled, onSoundSet, onRevealStateChange, bootComplete, ref }: TerminalProps) => {
   const isMobile = useIsMobile();
   const promptPrefix = '~ $ ';
   const { theme, setTheme } = useTheme();

--- a/src/components/Terminal/Terminal.tsx
+++ b/src/components/Terminal/Terminal.tsx
@@ -116,6 +116,15 @@ const Terminal = ({ onShutdown, onBell, playSound, soundEnabled, onSoundSet, onR
     });
   };
 
+  const displayMotd = (): TerminalLine[] => {
+    const hint = isMobile
+      ? 'Tap <span style="color: var(--terminal-primary)">≡</span> to explore commands.'
+      : 'Type <span style="color: var(--terminal-primary)">\'help\'</span> or press <span style="color: var(--terminal-primary)">Tab</span> to explore.';
+    return [
+      { content: `<span style="color: var(--terminal-gray)">${hint}</span>`, type: 'output' as const, isHtml: true },
+    ];
+  };
+
   const displayHelp = () => {
     return [
       { content: `${promptPrefix}help`, type: 'input' as const, timestamp: getCurrentTime() },
@@ -188,7 +197,7 @@ const Terminal = ({ onShutdown, onBell, playSound, soundEnabled, onSoundSet, onR
     if (trimmedCmd === '') return;
 
     if (trimmedCmd === 'clear') {
-      setTerminalOutput(displayHelp());
+      setTerminalOutput(displayMotd());
       setInputCommand('');
       setAutoSuggestion(null);
       return;
@@ -505,7 +514,7 @@ const Terminal = ({ onShutdown, onBell, playSound, soundEnabled, onSoundSet, onR
   };
 
   useEffect(() => {
-    setTerminalOutput(displayHelp());
+    setTerminalOutput(displayMotd());
     if (inputRef.current) {
       inputRef.current.focus();
     }
@@ -683,7 +692,6 @@ const Terminal = ({ onShutdown, onBell, playSound, soundEnabled, onSoundSet, onR
               onKeyDown={handleKeyDown}
               className="bg-transparent font-mono text-sm w-full focus:outline-none relative z-10 caret-transparent"
               style={{ color: 'var(--terminal-primary)' }}
-              placeholder={isMobile ? "Tap Cmds for suggestions..." : "Type a command or press Tab for suggestions..."}
               inputMode={isMobile ? "none" : undefined}
               autoCapitalize="none"
               spellCheck={false}

--- a/src/components/Terminal/Terminal.tsx
+++ b/src/components/Terminal/Terminal.tsx
@@ -120,6 +120,11 @@ const Terminal = ({ onShutdown, onBell, playSound, soundEnabled, onSoundSet, onR
     });
   };
 
+  // Plain-text MOTD hints (used by typing animation; HTML version derived below)
+  const motdPlainText = isMobile
+    ? 'Tap \u2261 to explore commands.'
+    : "Type 'help' or press Tab to explore.";
+
   const displayMotd = (): TerminalLine[] => {
     const hint = isMobile
       ? 'Tap <span style="color: var(--terminal-primary)">≡</span> to explore commands.'
@@ -127,6 +132,14 @@ const Terminal = ({ onShutdown, onBell, playSound, soundEnabled, onSoundSet, onR
     return [
       { content: `<span style="color: var(--terminal-gray)">${hint}</span>`, type: 'output' as const, isHtml: true },
     ];
+  };
+
+  const cancelMotdAnimation = () => {
+    if (!motdAnimatingRef.current) return;
+    motdAnimatingRef.current = false;
+    if (motdDelayRef.current) { clearTimeout(motdDelayRef.current); motdDelayRef.current = null; }
+    if (motdIntervalRef.current) { clearInterval(motdIntervalRef.current); motdIntervalRef.current = null; }
+    setTerminalOutput(displayMotd());
   };
 
   const displayHelp = () => {
@@ -182,12 +195,7 @@ const Terminal = ({ onShutdown, onBell, playSound, soundEnabled, onSoundSet, onR
 
   const handleInputChange = (e: ChangeEvent<HTMLInputElement>) => {
     if (isInputBlocked) return;
-    if (motdAnimatingRef.current) {
-      motdAnimatingRef.current = false;
-      if (motdDelayRef.current) { clearTimeout(motdDelayRef.current); motdDelayRef.current = null; }
-      if (motdIntervalRef.current) { clearInterval(motdIntervalRef.current); motdIntervalRef.current = null; }
-      setTerminalOutput(displayMotd());
-    }
+    cancelMotdAnimation();
     if (pendingExecuteRef.current) {
       clearTimeout(pendingExecuteRef.current);
       pendingExecuteRef.current = null;
@@ -202,12 +210,7 @@ const Terminal = ({ onShutdown, onBell, playSound, soundEnabled, onSoundSet, onR
 
   const handleCommand = (cmd: string) => {
     if (isInputBlocked) return;
-    if (motdAnimatingRef.current) {
-      motdAnimatingRef.current = false;
-      if (motdDelayRef.current) { clearTimeout(motdDelayRef.current); motdDelayRef.current = null; }
-      if (motdIntervalRef.current) { clearInterval(motdIntervalRef.current); motdIntervalRef.current = null; }
-      setTerminalOutput(displayMotd());
-    }
+    cancelMotdAnimation();
     const trimmedCmd = cmd.trim().toLowerCase();
 
     if (trimmedCmd === '') return;
@@ -433,12 +436,7 @@ const Terminal = ({ onShutdown, onBell, playSound, soundEnabled, onSoundSet, onR
 
   // Extracted action handlers for both keyboard and mobile button use
   const actionTab = () => {
-    if (motdAnimatingRef.current) {
-      motdAnimatingRef.current = false;
-      if (motdDelayRef.current) { clearTimeout(motdDelayRef.current); motdDelayRef.current = null; }
-      if (motdIntervalRef.current) { clearInterval(motdIntervalRef.current); motdIntervalRef.current = null; }
-      setTerminalOutput(displayMotd());
-    }
+    cancelMotdAnimation();
     if (showSuggestions) {
       selectSuggestion(selectedSuggestionIndex);
     } else if (autoSuggestion) {
@@ -578,10 +576,6 @@ const Terminal = ({ onShutdown, onBell, playSound, soundEnabled, onSoundSet, onR
       return;
     }
 
-    const plainText = isMobile
-      ? 'Tap \u2261 to explore commands.'
-      : "Type 'help' or press Tab to explore.";
-
     motdAnimatingRef.current = true;
     setTerminalOutput([{ content: '', type: 'output' }]);
 
@@ -591,7 +585,7 @@ const Terminal = ({ onShutdown, onBell, playSound, soundEnabled, onSoundSet, onR
       motdDelayRef.current = null;
 
       motdIntervalRef.current = setInterval(() => {
-        if (!motdAnimatingRef.current || charIndex >= plainText.length) {
+        if (!motdAnimatingRef.current || charIndex >= motdPlainText.length) {
           if (motdIntervalRef.current) clearInterval(motdIntervalRef.current);
           motdIntervalRef.current = null;
           motdAnimatingRef.current = false;
@@ -599,7 +593,7 @@ const Terminal = ({ onShutdown, onBell, playSound, soundEnabled, onSoundSet, onR
           return;
         }
         charIndex++;
-        setTerminalOutput([{ content: plainText.slice(0, charIndex), type: 'output' }]);
+        setTerminalOutput([{ content: motdPlainText.slice(0, charIndex), type: 'output' }]);
       }, 30);
     }, 300);
 

--- a/src/components/Terminal/Terminal.tsx
+++ b/src/components/Terminal/Terminal.tsx
@@ -57,6 +57,9 @@ const Terminal = ({ onShutdown, onBell, playSound, soundEnabled, onSoundSet, onR
   const suppressHoverRef = useRef(false);
   const spinnerTimeouts = useRef(new Set<ReturnType<typeof setTimeout>>());
   const spinnerIdRef = useRef(0);
+  const motdDelayRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const motdIntervalRef = useRef<ReturnType<typeof setInterval> | null>(null);
+  const motdAnimatingRef = useRef(false);
 
   const pendingExecuteRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const sentinelRef = useRef<HTMLDivElement>(null);
@@ -179,6 +182,12 @@ const Terminal = ({ onShutdown, onBell, playSound, soundEnabled, onSoundSet, onR
 
   const handleInputChange = (e: ChangeEvent<HTMLInputElement>) => {
     if (isInputBlocked) return;
+    if (motdAnimatingRef.current) {
+      motdAnimatingRef.current = false;
+      if (motdDelayRef.current) { clearTimeout(motdDelayRef.current); motdDelayRef.current = null; }
+      if (motdIntervalRef.current) { clearInterval(motdIntervalRef.current); motdIntervalRef.current = null; }
+      setTerminalOutput(displayMotd());
+    }
     if (pendingExecuteRef.current) {
       clearTimeout(pendingExecuteRef.current);
       pendingExecuteRef.current = null;
@@ -193,6 +202,12 @@ const Terminal = ({ onShutdown, onBell, playSound, soundEnabled, onSoundSet, onR
 
   const handleCommand = (cmd: string) => {
     if (isInputBlocked) return;
+    if (motdAnimatingRef.current) {
+      motdAnimatingRef.current = false;
+      if (motdDelayRef.current) { clearTimeout(motdDelayRef.current); motdDelayRef.current = null; }
+      if (motdIntervalRef.current) { clearInterval(motdIntervalRef.current); motdIntervalRef.current = null; }
+      setTerminalOutput(displayMotd());
+    }
     const trimmedCmd = cmd.trim().toLowerCase();
 
     if (trimmedCmd === '') return;
@@ -418,6 +433,12 @@ const Terminal = ({ onShutdown, onBell, playSound, soundEnabled, onSoundSet, onR
 
   // Extracted action handlers for both keyboard and mobile button use
   const actionTab = () => {
+    if (motdAnimatingRef.current) {
+      motdAnimatingRef.current = false;
+      if (motdDelayRef.current) { clearTimeout(motdDelayRef.current); motdDelayRef.current = null; }
+      if (motdIntervalRef.current) { clearInterval(motdIntervalRef.current); motdIntervalRef.current = null; }
+      setTerminalOutput(displayMotd());
+    }
     if (showSuggestions) {
       selectSuggestion(selectedSuggestionIndex);
     } else if (autoSuggestion) {
@@ -524,7 +545,7 @@ const Terminal = ({ onShutdown, onBell, playSound, soundEnabled, onSoundSet, onR
   };
 
   useEffect(() => {
-    setTerminalOutput(displayMotd());
+    setTerminalOutput([{ content: '', type: 'output' }]);
     if (inputRef.current) {
       inputRef.current.focus();
     }
@@ -546,6 +567,49 @@ const Terminal = ({ onShutdown, onBell, playSound, soundEnabled, onSoundSet, onR
     document.addEventListener('mousedown', handleClickOutside);
     return () => document.removeEventListener('mousedown', handleClickOutside);
   }, []);
+
+  // MOTD typing animation — triggered when boot splash completes
+  useEffect(() => {
+    if (!bootComplete) return;
+
+    // Reduced motion or no bootComplete prop: show MOTD instantly
+    if (reducedMotion) {
+      setTerminalOutput(displayMotd());
+      return;
+    }
+
+    const plainText = isMobile
+      ? 'Tap \u2261 to explore commands.'
+      : "Type 'help' or press Tab to explore.";
+
+    motdAnimatingRef.current = true;
+    setTerminalOutput([{ content: '', type: 'output' }]);
+
+    let charIndex = 0;
+
+    motdDelayRef.current = setTimeout(() => {
+      motdDelayRef.current = null;
+
+      motdIntervalRef.current = setInterval(() => {
+        if (!motdAnimatingRef.current || charIndex >= plainText.length) {
+          if (motdIntervalRef.current) clearInterval(motdIntervalRef.current);
+          motdIntervalRef.current = null;
+          motdAnimatingRef.current = false;
+          setTerminalOutput(displayMotd());
+          return;
+        }
+        charIndex++;
+        setTerminalOutput([{ content: plainText.slice(0, charIndex), type: 'output' }]);
+      }, 30);
+    }, 300);
+
+    return () => {
+      if (motdDelayRef.current) { clearTimeout(motdDelayRef.current); motdDelayRef.current = null; }
+      if (motdIntervalRef.current) { clearInterval(motdIntervalRef.current); motdIntervalRef.current = null; }
+      motdAnimatingRef.current = false;
+    };
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [bootComplete]);
 
   useEffect(() => {
     if (terminalRef.current) {
@@ -575,6 +639,8 @@ const Terminal = ({ onShutdown, onBell, playSound, soundEnabled, onSoundSet, onR
       timeouts.forEach(clearTimeout);
       timeouts.clear();
       if (pendingExecuteRef.current) clearTimeout(pendingExecuteRef.current);
+      if (motdDelayRef.current) clearTimeout(motdDelayRef.current);
+      if (motdIntervalRef.current) clearInterval(motdIntervalRef.current);
       cancelAnimationFrame(revealRafRef.current);
     };
   }, []);

--- a/src/components/Terminal/Terminal.tsx
+++ b/src/components/Terminal/Terminal.tsx
@@ -196,6 +196,15 @@ const Terminal = ({ onShutdown, onBell, playSound, soundEnabled, onSoundSet, onR
 
     if (trimmedCmd === '') return;
 
+    if (trimmedCmd === 'help') {
+      setTerminalOutput(prev => [...prev, ...displayHelp()]);
+      setCommandHistory(prev => [...prev, trimmedCmd].slice(-MAX_HISTORY));
+      setHistoryIndex(-1);
+      setInputCommand('');
+      setAutoSuggestion(null);
+      return;
+    }
+
     if (trimmedCmd === 'clear') {
       setTerminalOutput(displayMotd());
       setInputCommand('');

--- a/src/components/Terminal/__tests__/Suggestions.test.tsx
+++ b/src/components/Terminal/__tests__/Suggestions.test.tsx
@@ -15,7 +15,7 @@ const defaultProps = {
 };
 
 describe('Suggestions', () => {
-  it('renders all 10 command suggestions in commands mode', () => {
+  it('renders all 11 command suggestions in commands mode', () => {
     render(<Suggestions {...defaultProps} />);
     for (const s of suggestions) {
       expect(screen.getByText(s.command)).toBeInTheDocument();

--- a/src/components/Terminal/__tests__/Terminal.test.tsx
+++ b/src/components/Terminal/__tests__/Terminal.test.tsx
@@ -38,9 +38,11 @@ describe('Terminal', () => {
     vi.useRealTimers();
   });
 
-  it('renders help screen on mount', () => {
+  it('renders MOTD hint on mount', () => {
     renderWithProviders(<Terminal {...defaultProps} />);
-    expect(screen.getByText('Available commands:')).toBeInTheDocument();
+    expect(screen.getAllByText((_, el) =>
+      el?.tagName === 'SPAN' && /Type.*'help'.*Tab.*explore/.test(el.textContent ?? '')
+    ).length).toBeGreaterThan(0);
   });
 
   it('renders known command output after spinner delay', () => {
@@ -78,7 +80,7 @@ describe('Terminal', () => {
     expect(link.closest('a')).toHaveAttribute('href', 'https://github.com/dkoval');
   });
 
-  it('clears terminal and shows help on clear command', () => {
+  it('clears terminal and shows MOTD on clear command', () => {
     renderWithProviders(<Terminal {...defaultProps} />);
     submitCommand('history');
     act(() => { vi.advanceTimersByTime(600); });
@@ -87,6 +89,14 @@ describe('Terminal', () => {
     // Clear — synchronous, no timer needed
     submitCommand('clear');
     expect(screen.queryByText(/Still shipping/)).not.toBeInTheDocument();
+    expect(screen.getAllByText((_, el) =>
+      el?.tagName === 'SPAN' && /Type.*'help'.*Tab.*explore/.test(el.textContent ?? '')
+    ).length).toBeGreaterThan(0);
+  });
+
+  it('shows full help output when help command is typed', () => {
+    renderWithProviders(<Terminal {...defaultProps} />);
+    submitCommand('help');
     expect(screen.getByText('Available commands:')).toBeInTheDocument();
   });
 

--- a/src/components/Terminal/__tests__/Terminal.test.tsx
+++ b/src/components/Terminal/__tests__/Terminal.test.tsx
@@ -19,6 +19,7 @@ const defaultProps = {
   soundEnabled: false,
   onSoundSet: vi.fn(),
   onRevealStateChange: vi.fn(),
+  bootComplete: true,
 };
 
 // Helper: type a command and submit
@@ -98,6 +99,20 @@ describe('Terminal', () => {
     renderWithProviders(<Terminal {...defaultProps} />);
     submitCommand('help');
     expect(screen.getByText('Available commands:')).toBeInTheDocument();
+  });
+
+  it('snaps MOTD to final state on early user input', () => {
+    // Override reduced-motion to false so animation would normally play
+    mockMatchMedia(query => query === '(min-width: 768px)');
+    renderWithProviders(<Terminal {...defaultProps} />);
+    // Advance past the 300ms delay to start the animation
+    act(() => { vi.advanceTimersByTime(350); });
+    // User starts typing — animation should snap to final state
+    const input = screen.getByRole('textbox');
+    fireEvent.change(input, { target: { value: 'h' } });
+    expect(screen.getAllByText((_, el) =>
+      el?.tagName === 'SPAN' && /Type.*'help'.*Tab.*explore/.test(el.textContent ?? '')
+    ).length).toBeGreaterThan(0);
   });
 
   it('shows theme info when no argument given', () => {

--- a/src/components/Terminal/__tests__/commands.test.ts
+++ b/src/components/Terminal/__tests__/commands.test.ts
@@ -46,8 +46,8 @@ describe('commands registry', () => {
 });
 
 describe('suggestions', () => {
-  it('has exactly 10 entries', () => {
-    expect(suggestions).toHaveLength(10);
+  it('has exactly 11 entries', () => {
+    expect(suggestions).toHaveLength(11);
   });
 
   it('each entry has command, description, and icon', () => {
@@ -60,7 +60,7 @@ describe('suggestions', () => {
 
   const expectedCommands = [
     'whoami', 'man dmytro', 'skills', 'history', 'contact',
-    'uptime', 'theme', 'sound', 'clear', 'exit',
+    'uptime', 'theme', 'sound', 'help', 'clear', 'exit',
   ];
 
   it('contains all expected commands', () => {

--- a/src/components/Terminal/commands.tsx
+++ b/src/components/Terminal/commands.tsx
@@ -1,4 +1,4 @@
-import { Cpu, Mail, Sparkles, User, Info, Clock, LogOut, History, Palette, Volume2 } from 'lucide-react';
+import { Cpu, Mail, Sparkles, User, Info, Clock, LogOut, History, Palette, Volume2, HelpCircle } from 'lucide-react';
 import { CommandSuggestion } from './types';
 
 export const suggestions: CommandSuggestion[] = [
@@ -10,6 +10,7 @@ export const suggestions: CommandSuggestion[] = [
   { command: 'uptime', description: 'Session uptime', icon: <Clock className="w-4 h-4" style={{ color: 'var(--terminal-primary)' }} /> },
   { command: 'theme', description: 'Switch color theme', icon: <Palette className="w-4 h-4" style={{ color: 'var(--terminal-primary)' }} /> },
   { command: 'sound', description: 'Toggle terminal sounds', icon: <Volume2 className="w-4 h-4" style={{ color: 'var(--terminal-primary)' }} /> },
+  { command: 'help', description: 'Show available commands', icon: <HelpCircle className="w-4 h-4" style={{ color: 'var(--terminal-primary)' }} /> },
   { command: 'clear', description: 'Clear terminal screen', icon: <Sparkles className="w-4 h-4" style={{ color: 'var(--terminal-primary)' }} /> },
   { command: 'exit', description: 'Terminate the current session', icon: <LogOut className="w-4 h-4" style={{ color: 'var(--terminal-primary)' }} /> },
 ];


### PR DESCRIPTION
## Summary
- Replace 17-line auto-displayed help output with a single MOTD hint line on load and after `clear`
- Desktop: `Type 'help' or press Tab to explore.` / Mobile: `Tap ≡ to explore commands.`
- Add `help` as a real user-typeable command (previously gave "Command not found")
- Remove redundant input placeholder text (MOTD hint covers discoverability)

## Test Plan
- [x] 79 tests pass (13 test files, no regressions)
- [x] Desktop: MOTD hint shown on load, `help` command shows full listing, `clear` resets to MOTD
- [x] Mobile: MOTD shows `Tap ≡ to explore commands.` variant
- [x] Tab-completion suggests `help`, auto-suggestion ghost text works
- [x] `Ctrl+L` delegates to `clear` correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)