### PR TITLE
feat: mobile input redesign — typing-first with floating suggestions

### DIFF
--- a/docs/superpowers/plans/2026-03-22-mobile-input-redesign.md
+++ b/docs/superpowers/plans/2026-03-22-mobile-input-redesign.md
@@ -1,0 +1,797 @@
+# Mobile Input Redesign Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Show the native keyboard on mobile, reduce the helper row to `[↑] [↓]`, and replace the suggestion panel with a floating autocomplete dropdown triggered by typing, input focus, and prompt tap.
+
+**Architecture:** Remove `inputMode="none"` so the keyboard appears. Refactor `Suggestions.tsx` from a full panel overlay to a floating dropdown with prefix filtering and character highlighting. Simplify `App.tsx` toolbar from 4 buttons to 2. All changes gated by `useIsMobile` — desktop is untouched.
+
+**Tech Stack:** React 19, TypeScript 5.9, Vitest, @testing-library/react, Tailwind CSS 4
+
+**Spec:** `docs/superpowers/specs/2026-03-22-mobile-input-redesign-design.md`
+
+---
+
+## File Structure
+
+| File | Action | Responsibility |
+|------|--------|---------------|
+| `src/components/Terminal/TerminalInput.tsx` | Modify | Remove `inputMode="none"`, add `inputMode="search"`, `aria-expanded`, click-to-reopen callback |
+| `src/App.tsx` | Modify | Reduce toolbar to 2 buttons `[↑] [↓]`, remove Lucide icon imports, add `aria-label`s |
+| `src/components/Terminal/Terminal.tsx` | Modify | Narrow `TerminalHandle` to `'up' | 'down'`, refactor suggestion show/hide to state-driven triggers, add prefix filtering, update MOTD, add `role="log"` + `aria-live` on output |
+| `src/components/Terminal/Suggestions.tsx` | Modify | Restyle as floating dropdown, add `role="listbox"`/`role="option"`, accept `filterText` prop for character highlighting, enforce 44px touch targets |
+| `src/components/Terminal/__tests__/TerminalInput.test.tsx` | Create | Tests for inputMode, aria-expanded, click-to-reopen |
+| `src/components/Terminal/__tests__/Suggestions.test.tsx` | Modify | Add floating dropdown, ARIA, filtering highlight tests |
+| `src/components/Terminal/__tests__/Terminal.test.tsx` | Modify | Update MOTD assertion, update toolbar tests, add filtering tests |
+
+---
+
+### Task 1: Update TerminalInput — Keyboard Visibility, ARIA, Click-to-Reopen
+
+**Files:**
+- Modify: `src/components/Terminal/TerminalInput.tsx`
+- Create: `src/components/Terminal/__tests__/TerminalInput.test.tsx`
+
+- [ ] **Step 1: Write failing tests for TerminalInput**
+
+Create `src/components/Terminal/__tests__/TerminalInput.test.tsx`:
+
+```tsx
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import TerminalInput from '../TerminalInput';
+import { mockMatchMedia } from '../../../test/helpers';
+
+const baseProps = {
+  inputCommand: '',
+  inputRef: { current: null } as React.RefObject<HTMLInputElement | null>,
+  onInputChange: vi.fn(),
+  onKeyDown: vi.fn(),
+  isInputBlocked: false,
+  autoSuggestion: null,
+  isMobile: false,
+  showSuggestions: false,
+  onInputClick: vi.fn(),
+  onFocus: vi.fn(),
+};
+
+describe('TerminalInput', () => {
+  it('uses inputMode="search" on mobile', () => {
+    render(<TerminalInput {...baseProps} isMobile={true} />);
+    const input = screen.getByRole('textbox');
+    expect(input).toHaveAttribute('inputMode', 'search');
+  });
+
+  it('has no inputMode on desktop', () => {
+    render(<TerminalInput {...baseProps} isMobile={false} />);
+    const input = screen.getByRole('textbox');
+    expect(input).not.toHaveAttribute('inputMode');
+  });
+
+  it('sets aria-expanded based on showSuggestions prop', () => {
+    const { rerender } = render(<TerminalInput {...baseProps} showSuggestions={false} />);
+    const input = screen.getByRole('textbox');
+    expect(input).toHaveAttribute('aria-expanded', 'false');
+
+    rerender(<TerminalInput {...baseProps} showSuggestions={true} />);
+    expect(input).toHaveAttribute('aria-expanded', 'true');
+  });
+
+  it('calls onInputClick when input is clicked', () => {
+    const onInputClick = vi.fn();
+    render(<TerminalInput {...baseProps} onInputClick={onInputClick} />);
+    fireEvent.click(screen.getByRole('textbox'));
+    expect(onInputClick).toHaveBeenCalledOnce();
+  });
+});
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `npx vitest run src/components/Terminal/__tests__/TerminalInput.test.tsx`
+Expected: FAIL — `onInputClick` and `showSuggestions` props don't exist yet
+
+- [ ] **Step 3: Implement TerminalInput changes**
+
+In `src/components/Terminal/TerminalInput.tsx`:
+
+1. Add to props interface:
+```tsx
+showSuggestions: boolean;
+onInputClick?: () => void;
+onFocus?: () => void;
+```
+
+2. Replace the input element's `inputMode` line:
+```tsx
+// Old:
+inputMode={isMobile ? "none" : undefined}
+
+// New:
+inputMode={isMobile ? "search" : undefined}
+```
+
+3. Add `aria-expanded`, `onClick`, and `onFocus` to the input element:
+```tsx
+aria-expanded={showSuggestions}
+onClick={onInputClick}
+onFocus={onFocus}
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `npx vitest run src/components/Terminal/__tests__/TerminalInput.test.tsx`
+Expected: PASS (4 tests)
+
+- [ ] **Step 5: Run full test suite to check for regressions**
+
+Run: `npx vitest run`
+Expected: All existing tests pass. The new `showSuggestions` and `onInputClick` props need to be threaded from Terminal.tsx — existing Terminal tests won't break because TerminalInput is rendered internally and the props are optional/have defaults.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/components/Terminal/TerminalInput.tsx src/components/Terminal/__tests__/TerminalInput.test.tsx
+git commit -m "feat(mobile): show keyboard with inputMode=search, add aria-expanded and click-to-reopen"
+```
+
+---
+
+### Task 2: Reduce Mobile Toolbar to [↑] [↓]
+
+**Files:**
+- Modify: `src/App.tsx`
+
+- [ ] **Step 1: Write failing test for reduced toolbar**
+
+Add to `src/components/Terminal/__tests__/Terminal.test.tsx` (or a new App test file if preferred — but Terminal.test.tsx already tests mobile behavior):
+
+Since the toolbar lives in App.tsx and is hard to unit test in isolation (it uses terminalRef), we'll verify via the mobileKeys change and existing rendering. The key change is structural — update the array and types.
+
+Skip a dedicated test for this task; the type system will enforce correctness. Proceed directly to implementation.
+
+- [ ] **Step 2: Update mobileKeys array in App.tsx**
+
+In `src/App.tsx`, replace the `mobileKeys` array (lines 23-28):
+
+```tsx
+// Old:
+const mobileKeys = [
+  { label: 'Cmds', action: 'tab' as const, icon: true },
+  { label: '↑', action: 'up' as const },
+  { label: '↓', action: 'down' as const },
+  { label: '⏎ Enter', action: 'enter' as const, emphasized: true },
+];
+
+// New:
+const mobileKeys = [
+  { label: '↑', action: 'up' as const },
+  { label: '↓', action: 'down' as const },
+];
+```
+
+- [ ] **Step 3: Remove unused icon import and rendering logic**
+
+1. Remove the `List` import from `lucide-react` (used for the ≡ icon on the Cmds button).
+2. Remove the `icon` and `emphasized` fields from the button type and rendering. In the toolbar JSX, remove the conditional icon rendering (`{icon && <List ... />}`) and the emphasized style logic.
+3. Add `aria-label` to each button:
+
+```tsx
+<button
+  key={label}
+  className={`flex-1 py-3 font-mono text-sm rounded inline-flex items-center justify-center gap-1 ${isRevealing ? 'opacity-50 pointer-events-none' : ''}`}
+  style={MOBILE_BTN_STYLE}
+  data-mobile-action={action}
+  aria-label={action === 'up' ? 'Previous command' : 'Next command'}
+  onClick={() => {
+    navigator.vibrate?.(10);
+    terminalRef.current?.handleMobileAction(action);
+  }}
+>
+  {label}
+</button>
+```
+
+Note: `py-2` → `py-3` to ensure 48px minimum touch target height. Remove `MOBILE_BTN_STYLE_EMPHASIZED` constant if no longer used.
+
+- [ ] **Step 4: Update the MobileAction type**
+
+The `mobileKeys` type annotation (if any) and `handleMobileAction` call site now only pass `'up' | 'down'`. TypeScript will flag any remaining `'tab' | 'enter'` references after Task 3.
+
+- [ ] **Step 5: Run full test suite**
+
+Run: `npx vitest run`
+Expected: All tests pass. The toolbar change is purely in App.tsx rendering; Terminal tests that mock `handleMobileAction` still work since `'up'` and `'down'` are valid values.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/App.tsx
+git commit -m "feat(mobile): reduce toolbar to [↑] [↓], add aria-labels, remove Cmds/Enter buttons"
+```
+
+---
+
+### Task 3: Narrow TerminalHandle Type and Simplify useImperativeHandle
+
+**Files:**
+- Modify: `src/components/Terminal/Terminal.tsx`
+
+- [ ] **Step 1: Update TerminalHandle type**
+
+In `src/components/Terminal/Terminal.tsx` (line 91-93), narrow the action type:
+
+```tsx
+// Old:
+export type TerminalHandle = {
+  handleMobileAction: (action: 'tab' | 'up' | 'down' | 'enter') => void;
+};
+
+// New:
+export type TerminalHandle = {
+  handleMobileAction: (action: 'up' | 'down') => void;
+};
+```
+
+- [ ] **Step 2: Simplify useImperativeHandle**
+
+Replace the useImperativeHandle block (lines 596-607):
+
+```tsx
+// Old:
+useImperativeHandle(ref, () => ({
+  handleMobileAction: (action: 'tab' | 'up' | 'down' | 'enter') => {
+    if (isInputBlockedRef.current) return;
+    switch (action) {
+      case 'tab': actionTab(); break;
+      case 'up': actionUp(); break;
+      case 'down': actionDown(); break;
+      case 'enter': actionEnter(); break;
+    }
+    inputRef.current?.focus();
+  },
+}), [actionTab, actionUp, actionDown, actionEnter]);
+
+// New:
+useImperativeHandle(ref, () => ({
+  handleMobileAction: (action: 'up' | 'down') => {
+    if (isInputBlockedRef.current) return;
+    switch (action) {
+      case 'up': actionUp(); break;
+      case 'down': actionDown(); break;
+    }
+    inputRef.current?.focus();
+  },
+}), [actionUp, actionDown]);
+```
+
+- [ ] **Step 3: Verify actionTab and actionEnter are still used internally**
+
+`actionTab` is called from the desktop keyboard handler (`onKeyDown` for Tab key). `actionEnter` is called from the desktop Enter key handler. Both must remain — they are only removed from the *mobile imperative handle*, not from the component. Do NOT delete these functions.
+
+- [ ] **Step 4: Run full test suite + TypeScript check**
+
+Run: `npx vitest run && npx tsc --noEmit`
+Expected: All tests pass, no type errors. If App.tsx still references `'tab'` or `'enter'` in `handleMobileAction` calls, TypeScript will catch it — but Task 2 already removed those.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/components/Terminal/Terminal.tsx
+git commit -m "feat(mobile): narrow TerminalHandle to up/down only"
+```
+
+---
+
+### Task 4: Restyle Suggestions.tsx as Floating Dropdown with ARIA
+
+**Files:**
+- Modify: `src/components/Terminal/Suggestions.tsx`
+- Modify: `src/components/Terminal/__tests__/Suggestions.test.tsx`
+
+- [ ] **Step 1: Write failing tests for floating dropdown styling and ARIA**
+
+Add to `src/components/Terminal/__tests__/Suggestions.test.tsx`:
+
+```tsx
+it('has role="listbox" on the container', () => {
+  render(<Suggestions {...baseProps} />);
+  expect(screen.getByRole('listbox')).toBeInTheDocument();
+});
+
+it('has role="option" on each suggestion item', () => {
+  render(<Suggestions {...baseProps} />);
+  const options = screen.getAllByRole('option');
+  expect(options.length).toBe(baseProps.suggestions.length);
+});
+
+it('sets aria-label="Run <command>" on each item', () => {
+  render(<Suggestions {...baseProps} />);
+  const options = screen.getAllByRole('option');
+  expect(options[0]).toHaveAttribute('aria-label', `Run ${baseProps.suggestions[0].command}`);
+});
+
+it('highlights matching prefix when filterText is provided', () => {
+  render(<Suggestions {...baseProps} filterText="sk" />);
+  const option = screen.getByRole('option', { name: /Run skills/ });
+  const highlight = option.querySelector('[data-highlight="match"]');
+  expect(highlight).toHaveTextContent('sk');
+});
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `npx vitest run src/components/Terminal/__tests__/Suggestions.test.tsx`
+Expected: FAIL — no `role="listbox"`, no `role="option"`, no `filterText` prop
+
+- [ ] **Step 3: Add ARIA attributes and filterText prop**
+
+In `src/components/Terminal/Suggestions.tsx`:
+
+1. Add `filterText?: string` to props interface.
+
+2. Add `role="listbox"` to the outer container `<div>`.
+
+3. Change each suggestion `<button>` to include:
+```tsx
+role="option"
+aria-label={`Run ${suggestion.command}`}
+aria-selected={index === selectedIndex}
+```
+
+4. Add character highlighting helper inside the component:
+```tsx
+const highlightMatch = (command: string, filter: string) => {
+  if (!filter) return <span>{command}</span>;
+  const matchEnd = filter.length;
+  return (
+    <>
+      <span data-highlight="match" style={{ color: 'var(--terminal-primary)', fontWeight: 'bold' }}>
+        {command.slice(0, matchEnd)}
+      </span>
+      <span style={{ color: 'var(--terminal-gray)' }}>
+        {command.slice(matchEnd)}
+      </span>
+    </>
+  );
+};
+```
+
+5. Replace the command label rendering in commands mode to use `highlightMatch(suggestion.command, filterText ?? '')`.
+
+- [ ] **Step 4: Restyle as floating dropdown**
+
+Update the outer container styling in Suggestions.tsx. Replace the current full-width panel with floating dropdown:
+
+```tsx
+<div
+  ref={suggestionsRef}
+  role="listbox"
+  className="absolute bottom-full left-0 right-0 mb-1 z-20 overflow-y-auto rounded border"
+  style={{
+    maxHeight: 'min(50vh, 200px)',
+    background: 'var(--terminal-bg)',
+    borderColor: 'color-mix(in srgb, var(--terminal-primary) 30%, transparent)',
+  }}
+>
+```
+
+Note: `bottom-full` positions it above the input. `mb-1` adds a small gap. The parent (in Terminal.tsx) must have `position: relative` for this to work — verify this is already the case on the input wrapper.
+
+6. Ensure each suggestion item has min-height 44px:
+```tsx
+className="w-full px-4 py-2 flex items-center space-x-3 text-left text-sm transition-colors min-h-[44px]"
+```
+
+The current code already has `min-h-[44px] md:min-h-0`. Change to `min-h-[44px]` always (remove the `md:min-h-0` breakpoint — 44px is fine on desktop too).
+
+- [ ] **Step 5: Run tests to verify they pass**
+
+Run: `npx vitest run src/components/Terminal/__tests__/Suggestions.test.tsx`
+Expected: PASS
+
+- [ ] **Step 6: Run full test suite**
+
+Run: `npx vitest run`
+Expected: All tests pass. Terminal.tsx tests that render Suggestions may need the `filterText` prop — but it's optional with a default so existing tests shouldn't break.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add src/components/Terminal/Suggestions.tsx src/components/Terminal/__tests__/Suggestions.test.tsx
+git commit -m "feat(mobile): restyle Suggestions as floating dropdown with ARIA and prefix highlighting"
+```
+
+---
+
+### Task 5: Add Prefix Filtering and State-Driven Show/Hide Triggers
+
+**Files:**
+- Modify: `src/components/Terminal/Terminal.tsx`
+
+This is the largest task — it refactors how the suggestion dropdown opens, closes, and filters.
+
+- [ ] **Step 1: Write failing tests for filtering and show/hide behavior**
+
+Add to `src/components/Terminal/__tests__/Terminal.test.tsx`:
+
+```tsx
+describe('suggestion filtering (mobile)', () => {
+  beforeEach(() => {
+    setupTerminalMedia(true); // mobile mode
+  });
+
+  it('shows suggestions when input is focused and empty', async () => {
+    const { container } = renderWithProviders(<Terminal bootComplete={true} />);
+    const input = container.querySelector('input');
+    fireEvent.focus(input!);
+    expect(screen.getByRole('listbox')).toBeInTheDocument();
+  });
+
+  it('filters suggestions by prefix as user types', async () => {
+    const { container } = renderWithProviders(<Terminal bootComplete={true} />);
+    const input = container.querySelector('input');
+    fireEvent.focus(input!);
+    fireEvent.change(input!, { target: { value: 'sk' } });
+    const options = screen.getAllByRole('option');
+    expect(options).toHaveLength(1);
+    expect(options[0]).toHaveAttribute('aria-label', 'Run skills');
+  });
+
+  it('re-opens full list when input is backspaced to empty', async () => {
+    const { container } = renderWithProviders(<Terminal bootComplete={true} />);
+    const input = container.querySelector('input');
+    fireEvent.focus(input!);
+    fireEvent.change(input!, { target: { value: 's' } });
+    fireEvent.change(input!, { target: { value: '' } });
+    const options = screen.getAllByRole('option');
+    expect(options.length).toBeGreaterThan(1);
+  });
+
+  it('hides suggestions when no commands match', async () => {
+    const { container } = renderWithProviders(<Terminal bootComplete={true} />);
+    const input = container.querySelector('input');
+    fireEvent.focus(input!);
+    fireEvent.change(input!, { target: { value: 'xyz' } });
+    expect(screen.queryByRole('listbox')).not.toBeInTheDocument();
+  });
+});
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `npx vitest run src/components/Terminal/__tests__/Terminal.test.tsx`
+Expected: FAIL — suggestions don't show on focus, no filtering logic exists
+
+- [ ] **Step 3: Add filteredSuggestions derived state**
+
+In `src/components/Terminal/Terminal.tsx`, add a `useMemo` that filters `displaySuggestions` based on current input:
+
+```tsx
+const filteredSuggestions = useMemo(() => {
+  if (suggestionMode === 'themes') return displaySuggestions; // theme mode shows all themes, no filtering
+  const trimmed = inputCommand.trim().toLowerCase();
+  if (!trimmed) return displaySuggestions; // empty input = show all
+  return displaySuggestions.filter(s =>
+    s.command.toLowerCase().startsWith(trimmed)
+  );
+}, [displaySuggestions, inputCommand, suggestionMode]);
+```
+
+Pass `filteredSuggestions` to the `<Suggestions>` component instead of `displaySuggestions`. Also pass `filterText={inputCommand.trim()}`.
+
+**Critical:** Store filtered suggestions in a ref so `selectSuggestion` can index into the correct array:
+
+```tsx
+const filteredSuggestionsRef = useRef(filteredSuggestions);
+filteredSuggestionsRef.current = filteredSuggestions;
+```
+
+Then update `selectSuggestion` to use `filteredSuggestionsRef.current[index]` instead of `suggestions[index]` when in commands mode. The current code (line ~520) does `suggestions[index].command` — this must become `filteredSuggestionsRef.current[index].command`, otherwise selecting from a filtered list will execute the wrong command. For example: typing "sk" filters to `skills` at index 0, but `suggestions[0]` is `whoami`.
+
+- [ ] **Step 4: Refactor show/hide triggers**
+
+Modify the `onInputChange` handler (or wherever `setInputCommand` is called on user typing) to include suggestion show/hide logic:
+
+```tsx
+// In the onChange handler — IMPORTANT: preserve existing logic (cancelMotdAnimation,
+// pendingExecuteRef cancellation, setInputCommand, updateAutoSuggestion) from the
+// current handler. ADD the following suggestion show/hide logic after the existing lines:
+//
+  // Show/hide suggestions based on input
+  const trimmed = value.trim().toLowerCase();
+  if (trimmed === '') {
+    // Backspaced to empty — re-open full list
+    setShowSuggestions(true);
+    setSuggestionMode('commands');
+    setSelectedSuggestionIndex(0);
+  } else {
+    // Check if any commands match
+    const hasMatches = suggestions.some(s =>
+      s.command.toLowerCase().startsWith(trimmed)
+    );
+    setShowSuggestions(hasMatches);
+    if (hasMatches) {
+      setSuggestionMode('commands');
+      setSelectedSuggestionIndex(0);
+    }
+  }
+};
+```
+
+Add an `onFocus` handler for the input that shows suggestions when the input is empty:
+
+```tsx
+const handleInputFocus = useCallback(() => {
+  if (inputCommandRef.current.trim() === '') {
+    setShowSuggestions(true);
+    setSuggestionMode('commands');
+    setSelectedSuggestionIndex(0);
+  }
+}, []);
+```
+
+Add an `onInputClick` handler for the tap-to-reopen behavior:
+
+```tsx
+const handleInputClick = useCallback(() => {
+  if (inputCommandRef.current.trim() === '' && !showSuggestionsRef.current) {
+    setShowSuggestions(true);
+    setSuggestionMode('commands');
+    setSelectedSuggestionIndex(0);
+  }
+}, []);
+```
+
+Thread `handleInputFocus`, `handleInputClick`, and `showSuggestions` as props to `TerminalInput`.
+
+- [ ] **Step 5: Clamp selectedSuggestionIndex to filtered list length**
+
+The `actionUp` and `actionDown` callbacks currently use `suggestions.length` for wrapping. Update them to use `filteredSuggestions.length` when in commands mode. Store the filtered length in a ref so the callbacks can access it without stale closures:
+
+```tsx
+const filteredLengthRef = useRef(filteredSuggestions.length);
+filteredLengthRef.current = filteredSuggestions.length;
+```
+
+In `actionUp` and `actionDown`, replace:
+```tsx
+const len = suggestionModeRef.current === 'themes' ? VALID_THEMES.length : suggestions.length;
+```
+with:
+```tsx
+const len = suggestionModeRef.current === 'themes' ? VALID_THEMES.length : filteredLengthRef.current;
+```
+
+- [ ] **Step 6: Run tests to verify they pass**
+
+Run: `npx vitest run src/components/Terminal/__tests__/Terminal.test.tsx`
+Expected: PASS for the new filtering tests
+
+- [ ] **Step 7: Run full test suite**
+
+Run: `npx vitest run`
+Expected: All tests pass
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add src/components/Terminal/Terminal.tsx
+git commit -m "feat(mobile): add prefix filtering and state-driven suggestion show/hide triggers"
+```
+
+---
+
+### Task 6: Update Mobile MOTD
+
+**Files:**
+- Modify: `src/components/Terminal/Terminal.tsx`
+- Modify: `src/components/Terminal/__tests__/Terminal.test.tsx`
+
+- [ ] **Step 1: Update MOTD test**
+
+In `src/components/Terminal/__tests__/Terminal.test.tsx`, find the existing MOTD test (around line 42-47) and update or add:
+
+```tsx
+it('shows updated mobile MOTD', async () => {
+  setupTerminalMedia(true); // mobile
+  const { container } = renderWithProviders(<Terminal bootComplete={true} />);
+  await waitFor(() => {
+    expect(container.textContent).toContain("Type 'help' or tap the prompt to explore.");
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `npx vitest run src/components/Terminal/__tests__/Terminal.test.tsx`
+Expected: FAIL — MOTD still says "Tap ≡ to explore commands."
+
+- [ ] **Step 3: Update MOTD text in Terminal.tsx**
+
+Find the `displayMotd` callback and the `motdPlainText` variable. Update the mobile variants:
+
+```tsx
+// motdPlainText (used for typing animation character count):
+const motdPlainText = isMobile
+  ? "Type 'help' or tap the prompt to explore."
+  : "Type 'help' or press Tab to explore.";
+
+// displayMotd (HTML version):
+const displayMotd = useCallback((): TerminalLine[] => {
+  const hint = isMobileRef.current
+    ? 'Type <span style="color: var(--terminal-primary)">\'help\'</span> or <span style="color: var(--terminal-primary)">tap the prompt</span> to explore.'
+    : 'Type <span style="color: var(--terminal-primary)">\'help\'</span> or press <span style="color: var(--terminal-primary)">Tab</span> to explore.';
+  return [
+    { content: `<span style="color: var(--terminal-gray)">${hint}</span>`, type: 'output' as const, isHtml: true },
+  ];
+}, []);
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `npx vitest run src/components/Terminal/__tests__/Terminal.test.tsx`
+Expected: PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/components/Terminal/Terminal.tsx src/components/Terminal/__tests__/Terminal.test.tsx
+git commit -m "feat(mobile): update MOTD to 'Type help or tap the prompt to explore'"
+```
+
+---
+
+### Task 7: Add Accessibility Attributes to Terminal Output
+
+**Files:**
+- Modify: `src/components/Terminal/Terminal.tsx`
+- Modify: `src/components/Terminal/__tests__/Terminal.test.tsx`
+
+- [ ] **Step 1: Write failing test**
+
+Add to `src/components/Terminal/__tests__/Terminal.test.tsx`:
+
+```tsx
+it('terminal output container has role="log" and aria-live="polite"', () => {
+  setupTerminalMedia(false);
+  const { container } = renderWithProviders(<Terminal bootComplete={true} />);
+  const log = container.querySelector('[role="log"]');
+  expect(log).toBeInTheDocument();
+  expect(log).toHaveAttribute('aria-live', 'polite');
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `npx vitest run src/components/Terminal/__tests__/Terminal.test.tsx`
+Expected: FAIL — no element with `role="log"`
+
+- [ ] **Step 3: Add attributes to terminal output container**
+
+In Terminal.tsx, find the terminal output `<div>` that wraps the output lines (in the render JSX, around line 792-810). Add:
+
+```tsx
+<div role="log" aria-live="polite" className="...existing classes...">
+  {/* terminal output lines */}
+</div>
+```
+
+This is the scrollable container that holds all `terminalOutput` lines.
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `npx vitest run src/components/Terminal/__tests__/Terminal.test.tsx`
+Expected: PASS
+
+- [ ] **Step 5: Run full test suite**
+
+Run: `npx vitest run`
+Expected: All tests pass
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/components/Terminal/Terminal.tsx src/components/Terminal/__tests__/Terminal.test.tsx
+git commit -m "feat(a11y): add role=log and aria-live=polite to terminal output"
+```
+
+---
+
+### Task 8: Thread New Props and Integration Verification
+
+**Files:**
+- Modify: `src/components/Terminal/Terminal.tsx` (thread props to TerminalInput)
+- All test files
+
+This task ensures all new props (`showSuggestions`, `onInputClick`, `onFocus`, `filterText`) are properly connected between Terminal.tsx → TerminalInput.tsx → Suggestions.tsx.
+
+- [ ] **Step 1: Thread showSuggestions and handlers to TerminalInput**
+
+In Terminal.tsx, where `<TerminalInput>` is rendered, add the new props:
+
+```tsx
+<TerminalInput
+  inputCommand={inputCommand}
+  inputRef={inputRef}
+  onInputChange={handleInputChange}
+  onKeyDown={handleKeyDown}
+  isInputBlocked={isInputBlocked}
+  autoSuggestion={autoSuggestion}
+  isMobile={isMobile}
+  showSuggestions={showSuggestions}
+  onInputClick={handleInputClick}
+  onFocus={handleInputFocus}
+/>
+```
+
+Note: `onFocus` was already added to TerminalInput's props interface and wired to the `<input>` element in Task 1.
+
+- [ ] **Step 2: Thread filterText to Suggestions**
+
+In Terminal.tsx, where `<Suggestions>` is rendered, pass the filtered list and filter text:
+
+```tsx
+<Suggestions
+  suggestions={filteredSuggestions}
+  selectedIndex={selectedSuggestionIndex}
+  onSelect={selectSuggestion}
+  onMouseEnter={handleSuggestionMouseEnter}
+  ref={suggestionsRef}
+  mode={suggestionMode}
+  themes={VALID_THEMES}
+  currentTheme={theme}
+  onBack={backToCommands}
+  filterText={inputCommand.trim()}
+/>
+```
+
+- [ ] **Step 3: Run full test suite**
+
+Run: `npx vitest run`
+Expected: All tests pass — no regressions
+
+- [ ] **Step 4: Run TypeScript check**
+
+Run: `npx tsc --noEmit`
+Expected: No type errors
+
+- [ ] **Step 5: Manual mobile testing checklist**
+
+Run `npm run dev` and test on a mobile device or Chrome DevTools mobile emulation:
+
+1. [ ] Page loads → input focused → keyboard appears → suggestion dropdown shows all 11 commands
+2. [ ] Type "s" → dropdown filters to `skills`, `sound`
+3. [ ] Type "sk" → dropdown filters to `skills` only, "sk" highlighted in green
+4. [ ] Backspace to empty → dropdown shows full list
+5. [ ] Tap a suggestion → command fills input for 300ms → executes
+6. [ ] Tap outside dropdown (on terminal output) → dropdown closes
+7. [ ] Tap input → dropdown re-opens
+8. [ ] Press ↑ button with dropdown open → navigates suggestions
+9. [ ] Press ↑ button with dropdown closed → cycles command history
+10. [ ] Execute `theme` from suggestions → theme sub-menu appears in dropdown
+11. [ ] MOTD reads "Type 'help' or tap the prompt to explore."
+12. [ ] Keyboard Enter/Go key submits command
+13. [ ] Desktop behavior unchanged — Tab/Enter/arrows all work as before
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/components/Terminal/Terminal.tsx src/components/Terminal/TerminalInput.tsx
+git commit -m "feat(mobile): thread suggestion props through component tree, integration complete"
+```
+
+---
+
+## Task Dependency Order
+
+```
+Task 1 (TerminalInput) ──┐
+Task 2 (Toolbar)     ────┤
+Task 3 (TerminalHandle) ─┤──→ Task 5 (Filtering + Show/Hide) ──→ Task 8 (Integration)
+Task 4 (Suggestions)  ───┘
+Task 6 (MOTD) ─────────────→ (independent, can run anytime after Task 3)
+Task 7 (Accessibility) ────→ (independent, can run anytime)
+```
+
+Tasks 1-4 can be done in parallel. Task 5 depends on all four. Tasks 6-7 are independent. Task 8 ties everything together.

--- a/docs/superpowers/specs/2026-03-22-mobile-input-redesign-design.md
+++ b/docs/superpowers/specs/2026-03-22-mobile-input-redesign-design.md
@@ -1,0 +1,161 @@
+# Mobile Input Redesign — Design Spec
+
+## Problem
+
+Users report unintuitive navigation on mobile devices. Three specific pain points:
+
+1. **Discovery** — Users don't realize commands exist or how to find them
+2. **Mechanics** — The `[≡ Cmds] [↑] [↓] [⏎ Enter]` toolbar workflow requires too many taps to reach content
+3. **Keyboard expectation** — Users expect to type; the hidden keyboard (`inputMode="none"`) surprises them
+
+## Research Summary
+
+Thorough research across native terminal apps (Termux, Blink Shell, Prompt, Termius, a-Shell), terminal-themed websites, NNg/Google/Algolia UX guidelines, and accessibility standards produced one clear consensus: **every major mobile terminal app keeps the native keyboard visible and augments it with an extra key row**. Hiding the keyboard entirely contradicts user expectations and industry patterns.
+
+However, this site has only 11 fixed commands — fundamentally different from a general-purpose terminal. This enables aggressive autocomplete and real-time filtering that general-purpose terminals can't offer.
+
+## Design: Typing-First with Inline Floating Suggestions
+
+### Approach
+
+Show the native keyboard, remove the dedicated commands button, reduce the helper row to `[↑] [↓]`, and let the floating suggestion dropdown be the primary discovery and selection mechanism — triggered by typing, input focus, and prompt tap.
+
+---
+
+### 1. Input & Keyboard Behavior
+
+**Changes to `TerminalInput.tsx`:**
+
+- Remove `inputMode="none"`. Replace with `inputMode="search"` — shows keyboard with "Go"/"Search" return key instead of newline. Correct for command entry.
+- Keep `autoCapitalize="none"`, `spellCheck={false}`, `autoComplete="off"` — all correct for terminal input.
+- Keep custom blinking cursor via `<span>` and `caret-transparent` CSS.
+
+**Focus behavior:**
+
+- After boot splash completes, focus the input so keyboard appears immediately.
+- On iOS Safari, auto-focus may not open the keyboard without a user gesture. First tap on the terminal area must focus and open it.
+- Tapping outside the input area (on terminal output) does NOT dismiss the keyboard. The keyboard stays visible unless explicitly dismissed (swipe down on iOS, back button on Android).
+
+**Desktop:** Completely unchanged.
+
+### 2. Helper Row
+
+**Reduce from 4 buttons to 2:**
+
+Current: `[≡ Cmds] [↑] [↓] [⏎ Enter]`
+New: `[↑] [↓]`
+
+- `≡ Cmds` removed — discovery handled by autocomplete dropdown, MOTD hint, and tap-to-reopen on input.
+- `⏎ Enter` removed — the keyboard has its own return/go key.
+
+**Button behavior:**
+
+- **↑ / ↓ dual purpose:** When suggestion dropdown is visible, navigate the suggestion list. When dropdown is hidden, cycle through command history. Matches standard terminal behavior.
+- **Sizing:** Minimum 48px height per Google's touch target recommendation.
+- **Haptic feedback:** Keep existing 10ms vibrate on tap.
+- **Visual weight:** Slightly lighter background than terminal area, matching keyboard tone. Creates visual boundary: terminal (dark) → helper row (medium) → keyboard (light).
+- **Disabled during reveal:** Buttons get `opacity-50 pointer-events-none` while progressive output is animating.
+
+**Attributes preserved:**
+
+- `data-mobile-action` on each button (for click-outside handling).
+- `handleMobileAction` imperative handle — now accepts only `'up' | 'down'` (remove `'tab'` and `'enter'`).
+
+### 3. Floating Suggestion Dropdown
+
+The dropdown appears as a floating list above the input line — not a full-screen panel.
+
+**Show triggers:**
+
+- Focus empty input (initial page load, after keyboard dismiss/refocus)
+- Type any character (filters in real-time)
+- Tap the input when it's focused, empty, and dropdown is hidden (re-open)
+
+**Hide triggers:**
+
+- Execute a command
+- Tap outside the dropdown (on terminal output)
+- No matching commands for current input
+
+**Filtering:**
+
+- Real-time prefix match, case-insensitive
+- Matched characters highlighted in terminal-primary color (bold), rest dimmed
+- Single match auto-highlighted for immediate Enter/Go execution
+
+**Selection:**
+
+- Tap any item directly to select
+- Use ↑/↓ helper buttons to navigate, then keyboard Enter/Go to execute
+- Selected command fills input for 300ms → auto-executes (current behavior preserved)
+
+**Sizing:**
+
+- Max height: `min(50vh, 200px)` with `overflow-y: auto`
+- Shows ~4-5 items without scrolling, scrollable for full list
+- Prevents covering entire shrunken viewport when keyboard is open
+
+**Sub-menus:**
+
+- Theme sub-menu: same dropdown, content swaps to theme list with color indicators. "← Commands" link to return. Tapping a theme executes `theme <name>`.
+- Sound toggle: tapping `sound` from suggestions directly toggles (current behavior preserved).
+
+**≡ Cmds toggle behavior removed.** The dropdown is now purely state-driven (show/hide based on triggers above), not toggled by a button.
+
+### 4. MOTD Update
+
+**Current mobile MOTD:** `Tap ≡ to explore commands.`
+**New mobile MOTD:** `Type 'help' or tap the prompt to explore.`
+
+- Consistent structure with desktop: `Type 'help' or press Tab to explore.`
+- "tap the prompt" refers to tapping the `$` input area to re-open the dropdown
+- Styled with terminal-primary color on `'help'` and `the prompt` (matching desktop styling of `'help'` and `Tab`)
+- MOTD typing animation behavior unchanged (300ms delay, 30ms/char on boot, skip for `prefers-reduced-motion`)
+
+### 5. Viewport & Layout
+
+**Keyboard impact:** The soft keyboard consumes ~40-50% of screen height on mobile.
+
+- Let the browser handle viewport resize naturally. Do not use VirtualKeyboard API (not supported on Safari).
+- Terminal output area is already a flex column — it shrinks when keyboard pushes up the bottom.
+- Existing `scrollIntoView` on input after command execution keeps recent output and input visible.
+- Helper row sticks above keyboard as part of the bottom fixed area, moves with viewport resize.
+- No layout changes on desktop — gated by `useIsMobile` hook.
+
+### 6. Accessibility
+
+Targeted improvements scoped to mobile input changes:
+
+- **`role="log"` + `aria-live="polite"`** on terminal output container — screen readers announce new output when idle.
+- **`aria-label`** on helper buttons: `↑` → `"Previous command"`, `↓` → `"Next command"`.
+- **`aria-label`** on dropdown items: `"Run <command>"` (e.g., "Run whoami").
+- **`role="listbox"`** on dropdown container, **`role="option"`** on each item.
+- **`aria-expanded`** on the input element — reflects dropdown open/closed state.
+- **Minimum 44px touch targets** on dropdown items (padding to meet threshold).
+
+**Out of scope:** Full screen reader mode, braille spinner accessibility, progressive reveal screen reader support.
+
+---
+
+## What Stays the Same
+
+- Desktop behavior — completely untouched
+- Progressive output reveal + input blocking during animation
+- Theme sub-menu flow inside dropdown
+- Sound toggle behavior
+- 300ms command preview before auto-execute
+- `RESPONSIVE_COMMANDS` mobile/desktop output variants
+- Boot splash, shutdown sequence, CRT effects
+- `useIsMobile` hook, 768px breakpoint
+- `key={sessionKey}` remount pattern
+
+## Files Affected
+
+| File | Changes |
+|------|---------|
+| `src/components/Terminal/TerminalInput.tsx` | Remove `inputMode="none"`, add `inputMode="search"`, add `aria-expanded`, add click-to-reopen handler |
+| `src/components/Terminal/Terminal.tsx` | Refactor suggestion dropdown to floating style, add filtering with character highlighting, add ↑/↓ dual-role logic, update MOTD text, add ARIA attributes to dropdown, update `TerminalHandle` type |
+| `src/App.tsx` | Remove `≡ Cmds` and `⏎ Enter` from toolbar, remove Lucide `List`/`Terminal` icon imports, update `mobileKeys` array, simplify layout |
+| `src/components/Terminal/Suggestions.tsx` | Restyle as floating dropdown, add max-height constraint, add `role="listbox"`/`role="option"`, ensure 44px touch targets |
+| `src/index.css` | Any mobile-specific dropdown positioning styles |
+| Tests | Update mobile toolbar tests, add dropdown filtering tests, update MOTD assertion |

--- a/docs/superpowers/specs/2026-03-22-mobile-input-redesign-design.md
+++ b/docs/superpowers/specs/2026-03-22-mobile-input-redesign-design.md
@@ -76,6 +76,7 @@ The dropdown appears as a floating list above the input line — not a full-scre
 - Execute a command
 - Tap outside the dropdown (on terminal output)
 - No matching commands for current input
+- Backspacing to empty re-opens the full command list (treated as a "show" trigger, not a "hide")
 
 **Filtering:**
 

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -2,21 +2,10 @@ import { useState, useCallback, useRef, useEffect } from 'react';
 import BootSplash from './components/BootSplash';
 import Sidebar from './components/Sidebar';
 import TerminalWindow from './components/TerminalWindow';
-import Terminal, { TerminalHandle } from './components/Terminal';
+import Terminal from './components/Terminal';
 import { resetPageLoadTime } from './constants';
 import { useTheme } from './ThemeContext';
 import useSoundEngine from './hooks/useSoundEngine';
-
-const MOBILE_BTN_STYLE = {
-  background: 'var(--terminal-surface)',
-  color: 'var(--terminal-primary)',
-  border: '1px solid var(--terminal-border)',
-} as const;
-
-const mobileKeys = [
-  { label: '↑', action: 'up' as const },
-  { label: '↓', action: 'down' as const },
-];
 
 const SHUTDOWN_MESSAGES = [
   'Broadcast message from root@dkoderinc (pts/0):',
@@ -47,8 +36,6 @@ const App = () => {
     setShowBootSplash(false);
     sound.play('boot');
   }, [sound]);
-  const terminalRef = useRef<TerminalHandle>(null);
-
   const [bellFlash, setBellFlash] = useState(false);
   const bellTimerRef = useRef<ReturnType<typeof setTimeout>>(null);
 
@@ -64,8 +51,6 @@ const App = () => {
   useEffect(() => {
     return () => { if (bellTimerRef.current) clearTimeout(bellTimerRef.current); };
   }, []);
-
-  const [isRevealing, setIsRevealing] = useState(false);
 
   const [shutdownPhase, setShutdownPhase] = useState<ShutdownPhase>(null);
   const [shutdownLines, setShutdownLines] = useState(0);
@@ -245,38 +230,15 @@ const App = () => {
             <TerminalWindow bellFlash={bellFlash} onSoundToggle={sound.toggle} soundEnabled={sound.enabled}>
               <Terminal
                 key={sessionKey}
-                ref={terminalRef}
                 onShutdown={handleShutdown}
                 onBell={handleBell}
                 playSound={sound.play}
                 soundEnabled={sound.enabled}
                 onSoundSet={sound.setEnabled}
-                onRevealStateChange={setIsRevealing}
                 bootComplete={!showBootSplash}
               />
             </TerminalWindow>
           </main>
-        </div>
-        {/* Mobile virtual keyboard shortcuts */}
-        <div
-          className="flex md:hidden shrink-0 gap-2 p-2 border-t"
-          style={{ borderColor: 'var(--terminal-border)' }}
-        >
-          {mobileKeys.map(({ label, action }) => (
-            <button
-              key={label}
-              className={`flex-1 py-3 font-mono text-sm rounded inline-flex items-center justify-center gap-1 ${isRevealing ? 'opacity-50 pointer-events-none' : ''}`}
-              style={MOBILE_BTN_STYLE}
-              data-mobile-action={action}
-              aria-label={action === 'up' ? 'Previous command' : 'Next command'}
-              onClick={() => {
-                navigator.vibrate?.(10);
-                terminalRef.current?.handleMobileAction(action);
-              }}
-            >
-              {label}
-            </button>
-          ))}
         </div>
         {/* Copyright */}
         <div

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -4,7 +4,6 @@ import Sidebar from './components/Sidebar';
 import TerminalWindow from './components/TerminalWindow';
 import Terminal, { TerminalHandle } from './components/Terminal';
 import { resetPageLoadTime } from './constants';
-import { List } from 'lucide-react';
 import { useTheme } from './ThemeContext';
 import useSoundEngine from './hooks/useSoundEngine';
 
@@ -14,17 +13,9 @@ const MOBILE_BTN_STYLE = {
   border: '1px solid var(--terminal-border)',
 } as const;
 
-const MOBILE_BTN_STYLE_EMPHASIZED = {
-  background: 'var(--terminal-primary)',
-  color: 'var(--terminal-bg)',
-  border: '1px solid var(--terminal-primary)',
-} as const;
-
 const mobileKeys = [
-  { label: 'Cmds', action: 'tab' as const, icon: true },
   { label: '↑', action: 'up' as const },
   { label: '↓', action: 'down' as const },
-  { label: '⏎ Enter', action: 'enter' as const, emphasized: true },
 ];
 
 const SHUTDOWN_MESSAGES = [
@@ -271,18 +262,18 @@ const App = () => {
           className="flex md:hidden shrink-0 gap-2 p-2 border-t"
           style={{ borderColor: 'var(--terminal-border)' }}
         >
-          {mobileKeys.map(({ label, action, icon, emphasized }) => (
+          {mobileKeys.map(({ label, action }) => (
             <button
               key={label}
-              className={`flex-1 py-2 font-mono text-sm rounded inline-flex items-center justify-center gap-1 ${isRevealing ? 'opacity-50 pointer-events-none' : ''}`}
-              style={emphasized ? MOBILE_BTN_STYLE_EMPHASIZED : MOBILE_BTN_STYLE}
+              className={`flex-1 py-3 font-mono text-sm rounded inline-flex items-center justify-center gap-1 ${isRevealing ? 'opacity-50 pointer-events-none' : ''}`}
+              style={MOBILE_BTN_STYLE}
               data-mobile-action={action}
+              aria-label={action === 'up' ? 'Previous command' : 'Next command'}
               onClick={() => {
                 navigator.vibrate?.(10);
                 terminalRef.current?.handleMobileAction(action);
               }}
             >
-              {icon && <List className="w-3.5 h-3.5" />}
               {label}
             </button>
           ))}

--- a/src/components/Terminal/Suggestions.tsx
+++ b/src/components/Terminal/Suggestions.tsx
@@ -17,7 +17,7 @@ interface SuggestionsProps {
 }
 
 const highlightMatch = (command: string, filter: string) => {
-  if (!filter) return <span>{command}</span>;
+  if (!filter) return <span style={{ color: 'var(--terminal-primary)' }}>{command}</span>;
   const matchEnd = filter.length;
   return (
     <>
@@ -37,7 +37,7 @@ const Suggestions = memo(({ suggestions, selectedIndex, onSelect, onMouseEnter, 
         ref={ref}
         id="terminal-suggestions"
         role="listbox"
-        className="absolute bottom-full left-0 right-0 mb-1 z-20 overflow-y-auto rounded border"
+        className="absolute bottom-full left-0 right-0 mb-1 z-20 overflow-y-auto rounded border scrollbar-hide"
         style={{
           maxHeight: 'min(50vh, 200px)',
           background: 'var(--terminal-bg)',
@@ -70,9 +70,9 @@ const Suggestions = memo(({ suggestions, selectedIndex, onSelect, onMouseEnter, 
                 onMouseEnter={() => onMouseEnter(index)}
               >
                 {suggestion.icon}
-                <span className="font-mono">{highlightMatch(suggestion.command, filterText ?? '')}</span>
-                <span style={{ color: 'var(--terminal-primary-dark)' }}>-</span>
-                <span style={{ color: 'var(--terminal-gray)' }}>{suggestion.description}</span>
+                <span className="font-mono shrink-0">{highlightMatch(suggestion.command, filterText ?? '')}</span>
+                <span className="shrink-0" style={{ color: 'var(--terminal-primary-dark)' }}>-</span>
+                <span className="truncate" style={{ color: 'var(--terminal-gray)' }}>{suggestion.description}</span>
               </button>
             ))
           : themes?.map((t, index) => (

--- a/src/components/Terminal/Suggestions.tsx
+++ b/src/components/Terminal/Suggestions.tsx
@@ -12,19 +12,41 @@ interface SuggestionsProps {
   themes?: ThemeName[];
   currentTheme?: ThemeName;
   onBack?: () => void;
+  filterText?: string;
   ref?: Ref<HTMLDivElement>;
 }
 
-const Suggestions = memo(({ suggestions, selectedIndex, onSelect, onMouseEnter, mode, themes, currentTheme, onBack, ref }: SuggestionsProps) => {
+const highlightMatch = (command: string, filter: string) => {
+  if (!filter) return <span>{command}</span>;
+  const matchEnd = filter.length;
+  return (
+    <>
+      <span data-highlight="match" style={{ color: 'var(--terminal-primary)', fontWeight: 'bold' }}>
+        {command.slice(0, matchEnd)}
+      </span>
+      <span style={{ color: 'var(--terminal-gray)' }}>
+        {command.slice(matchEnd)}
+      </span>
+    </>
+  );
+};
+
+const Suggestions = memo(({ suggestions, selectedIndex, onSelect, onMouseEnter, mode, themes, currentTheme, onBack, filterText, ref }: SuggestionsProps) => {
     return (
       <div
         ref={ref}
-        className="absolute bottom-full mb-2 w-full shadow-lg overflow-hidden"
-        style={{ background: 'var(--terminal-bg)', border: '1px solid var(--terminal-border)' }}
+        id="terminal-suggestions"
+        role="listbox"
+        className="absolute bottom-full left-0 right-0 mb-1 z-20 overflow-y-auto rounded border"
+        style={{
+          maxHeight: 'min(50vh, 200px)',
+          background: 'var(--terminal-bg)',
+          borderColor: 'color-mix(in srgb, var(--terminal-primary) 30%, transparent)',
+        }}
       >
         {mode === 'themes' && (
           <button
-            className="w-full px-4 py-2 flex items-center space-x-2 text-left text-sm border-b min-h-[44px] md:min-h-0"
+            className="w-full px-4 py-2 flex items-center space-x-2 text-left text-sm border-b min-h-[44px]"
             style={{ color: 'var(--terminal-gray)', borderColor: 'var(--terminal-border)' }}
             onClick={onBack}
           >
@@ -36,7 +58,10 @@ const Suggestions = memo(({ suggestions, selectedIndex, onSelect, onMouseEnter, 
           ? suggestions.map((suggestion, index) => (
               <button
                 key={suggestion.command}
-                className="w-full px-4 py-2 flex items-center space-x-3 text-left text-sm transition-colors min-h-[44px] md:min-h-0"
+                role="option"
+                aria-label={`Run ${suggestion.command}`}
+                aria-selected={index === selectedIndex}
+                className="w-full px-4 py-2 flex items-center space-x-3 text-left text-sm transition-colors min-h-[44px]"
                 style={{
                   background: index === selectedIndex ? 'var(--terminal-surface)' : 'transparent',
                   borderLeft: index === selectedIndex ? '2px solid var(--terminal-primary)' : '2px solid transparent',
@@ -45,7 +70,7 @@ const Suggestions = memo(({ suggestions, selectedIndex, onSelect, onMouseEnter, 
                 onMouseEnter={() => onMouseEnter(index)}
               >
                 {suggestion.icon}
-                <span className="font-mono" style={{ color: 'var(--terminal-primary)' }}>{suggestion.command}</span>
+                <span className="font-mono">{highlightMatch(suggestion.command, filterText ?? '')}</span>
                 <span style={{ color: 'var(--terminal-primary-dark)' }}>-</span>
                 <span style={{ color: 'var(--terminal-gray)' }}>{suggestion.description}</span>
               </button>
@@ -53,7 +78,10 @@ const Suggestions = memo(({ suggestions, selectedIndex, onSelect, onMouseEnter, 
           : themes?.map((t, index) => (
               <button
                 key={t}
-                className="w-full px-4 py-2 flex items-center space-x-3 text-left text-sm transition-colors min-h-[44px] md:min-h-0"
+                role="option"
+                aria-label={`Run ${t}`}
+                aria-selected={index === selectedIndex}
+                className="w-full px-4 py-2 flex items-center space-x-3 text-left text-sm transition-colors min-h-[44px]"
                 style={{
                   background: index === selectedIndex ? 'var(--terminal-surface)' : 'transparent',
                   borderLeft: index === selectedIndex ? '2px solid var(--terminal-primary)' : '2px solid transparent',

--- a/src/components/Terminal/Suggestions.tsx
+++ b/src/components/Terminal/Suggestions.tsx
@@ -1,4 +1,4 @@
-import { Ref, memo } from 'react';
+import { Ref, memo, useEffect, useRef } from 'react';
 import { ChevronLeft, Palette } from 'lucide-react';
 import { CommandSuggestion } from './types';
 import { ThemeName } from '../../ThemeContext';
@@ -32,14 +32,29 @@ const highlightMatch = (command: string, filter: string) => {
 };
 
 const Suggestions = memo(({ suggestions, selectedIndex, onSelect, onMouseEnter, mode, themes, currentTheme, onBack, filterText, ref }: SuggestionsProps) => {
+    const listRef = useRef<HTMLDivElement>(null);
+
+    useEffect(() => {
+      const container = listRef.current;
+      if (!container) return;
+      const selected = container.querySelector('[aria-selected="true"]');
+      if (selected && 'scrollIntoView' in selected) {
+        selected.scrollIntoView({ block: 'nearest' });
+      }
+    }, [selectedIndex]);
+
     return (
       <div
-        ref={ref}
+        ref={(node) => {
+          listRef.current = node;
+          if (typeof ref === 'function') ref(node);
+          else if (ref) (ref as React.MutableRefObject<HTMLDivElement | null>).current = node;
+        }}
         id="terminal-suggestions"
         role="listbox"
         className="absolute bottom-full left-0 right-0 mb-1 z-20 overflow-y-auto rounded border scrollbar-hide"
         style={{
-          maxHeight: 'min(50vh, 200px)',
+          maxHeight: 'min(50vh, 440px)',
           background: 'var(--terminal-bg)',
           borderColor: 'color-mix(in srgb, var(--terminal-primary) 30%, transparent)',
         }}

--- a/src/components/Terminal/Terminal.tsx
+++ b/src/components/Terminal/Terminal.tsx
@@ -598,6 +598,8 @@ const Terminal = ({ onShutdown, onBell, playSound, soundEnabled, onSoundSet, onR
 
   const actionUp = useCallback(() => {
     if (showSuggestionsRef.current) {
+      suppressHoverRef.current = true;
+      setTimeout(() => { suppressHoverRef.current = false; }, 100);
       const len = suggestionModeRef.current === 'themes' ? VALID_THEMES.length : filteredSuggestionsRef.current.length;
       setSelectedSuggestionIndex(prev => prev > 0 ? prev - 1 : len - 1);
     } else if (commandHistoryRef.current.length > 0) {
@@ -613,6 +615,8 @@ const Terminal = ({ onShutdown, onBell, playSound, soundEnabled, onSoundSet, onR
 
   const actionDown = useCallback(() => {
     if (showSuggestionsRef.current) {
+      suppressHoverRef.current = true;
+      setTimeout(() => { suppressHoverRef.current = false; }, 100);
       const len = suggestionModeRef.current === 'themes' ? VALID_THEMES.length : filteredSuggestionsRef.current.length;
       setSelectedSuggestionIndex(prev => prev < len - 1 ? prev + 1 : 0);
     } else if (commandHistoryRef.current.length > 0) {

--- a/src/components/Terminal/Terminal.tsx
+++ b/src/components/Terminal/Terminal.tsx
@@ -1,13 +1,14 @@
 import { useState, useEffect, useRef, useImperativeHandle, useMemo, useCallback, ChangeEvent, KeyboardEvent, Ref } from 'react';
 import type DOMPurifyType from 'dompurify';
-import { suggestions, commands } from './commands';
+import { suggestions } from './commands';
 import { Volume2, VolumeX } from 'lucide-react';
 import { TerminalLine } from './types';
 import Suggestions from './Suggestions';
 import TerminalOutput from './TerminalOutput';
 import TerminalInput from './TerminalInput';
-import { PAGE_LOAD_TIME, formatUptime, hexToRgba } from '../../constants';
+import { hexToRgba, getCurrentTime } from '../../constants';
 import { useTheme, ThemeName, VALID_THEMES } from '../../ThemeContext';
+import { resolveCommand } from './commandResolver';
 import useIsMobile from '../../hooks/useIsMobile';
 import { SoundType } from '../../hooks/useSoundEngine';
 import useIdleTimer from '../../hooks/useIdleTimer';
@@ -19,10 +20,6 @@ export const MAX_OUTPUT = 500;
 export const appendOutput = (prev: TerminalLine[], ...lines: TerminalLine[]): TerminalLine[] =>
   [...prev, ...lines].slice(-MAX_OUTPUT);
 const PURIFY_CONFIG = { ADD_ATTR: ['target', 'style'], ADD_TAGS: ['svg', 'path', 'rect', 'circle', 'polyline'] };
-const THEME_EASTER_EGGS: Partial<Record<ThemeName, string>> = {
-  'tokyo-night': 'Welcome to Neo-Tokyo. The night shift begins.',
-  'one-dark-pro': 'Dark mode activated. Your eyes will thank you.',
-};
 
 const THEME_HEX_COLORS: Record<ThemeName, string> = {
   green: '#00FF41',
@@ -74,19 +71,6 @@ const sanitizeHtml = async (content: string): Promise<string> => {
     }
   }
   return purifyInstance.sanitize(content, PURIFY_CONFIG);
-};
-
-const getCurrentTime = () =>
-  new Date().toLocaleTimeString('en-US', {
-    hour12: false,
-    hour: '2-digit',
-    minute: '2-digit',
-    second: '2-digit',
-  });
-
-const RESPONSIVE_COMMANDS: Record<string, { mobile: string; desktop: string }> = {
-  whoami: { mobile: 'whoami', desktop: 'whoamiDesktop' },
-  skills: { mobile: 'skillsMobile', desktop: 'skills' },
 };
 
 export type TerminalHandle = {
@@ -423,106 +407,45 @@ const Terminal = ({ onShutdown, onBell, playSound, soundEnabled, onSoundSet, onR
         }
       };
 
-      let outputLines: TerminalLine[];
+      const result = resolveCommand(trimmedCmd, {
+        isMobile: isMobileRef.current,
+        theme: themeRef.current,
+        soundEnabled: !!soundEnabledRef.current,
+      });
 
-      if (trimmedCmd in RESPONSIVE_COMMANDS) {
-        const variant = RESPONSIVE_COMMANDS[trimmedCmd];
-        const key = isMobileRef.current ? variant.mobile : variant.desktop;
-        outputLines = commands[key].map(line => ({
-          content: line,
-          type: 'output' as const,
-        }));
-      } else if (trimmedCmd === 'uptime') {
-        const seconds = Math.floor((Date.now() - PAGE_LOAD_TIME) / 1000);
-        const timeStr = getCurrentTime();
-        const base = (Date.now() % 100) / 100;
-        const load1 = (0.3 + base * 0.4).toFixed(2);
-        const load5 = (0.2 + base * 0.25).toFixed(2);
-        const load15 = (0.05 + base * 0.15).toFixed(2);
-        outputLines = [
-          { content: ` ${timeStr} up ${formatUptime(seconds)},  1 user,  load average: ${load1}, ${load5}, ${load15}`, type: 'output' },
-        ];
-      } else if (trimmedCmd === 'theme' || trimmedCmd.startsWith('theme ')) {
-        const arg = trimmedCmd.replace('theme', '').trim();
-        if (!arg) {
-          outputLines = [
-            { content: `Current theme: ${themeRef.current}`, type: 'output' },
-            { content: `Available: ${VALID_THEMES.join(', ')}`, type: 'output' },
-            { content: `Usage: theme <name>`, type: 'output' },
-          ];
-        } else if (VALID_THEMES.includes(arg as ThemeName)) {
-          const eggMessage = THEME_EASTER_EGGS[arg as ThemeName];
-          const eggKey = `dkoder-${arg}-seen`;
-          const isFirstTime = eggMessage && !localStorage.getItem(eggKey);
-          setTheme(arg as ThemeName);
-          playSoundRef.current?.('themeSwitch');
-          if (isFirstTime) {
-            localStorage.setItem(eggKey, '1');
-            outputLines = [
-              { content: eggMessage, type: 'output' },
-            ];
-          } else {
-            outputLines = [
-              { content: `Theme switched to ${arg}.`, type: 'output' },
-            ];
-          }
-        } else {
-          outputLines = [
-            { content: `Unknown theme: ${arg}. Available: ${VALID_THEMES.join(', ')}`, type: 'error' },
-          ];
+      result.effects?.forEach(effect => {
+        switch (effect.type) {
+          case 'setTheme':
+            setTheme(effect.theme);
+            playSoundRef.current?.('themeSwitch');
+            break;
+          case 'setSoundEnabled':
+            onSoundSetRef.current?.(effect.enabled);
+            break;
+          case 'bell':
+            onBellRef.current?.();
+            playSoundRef.current?.('error');
+            break;
         }
-      } else if (trimmedCmd === 'sound' || trimmedCmd.startsWith('sound ')) {
-        const arg = trimmedCmd.replace('sound', '').trim();
-        if (!arg) {
-          outputLines = [
-            { content: `Sound: ${soundEnabledRef.current ? 'on' : 'off'}`, type: 'output' },
-            { content: `Usage: sound <on|off>`, type: 'output' },
-          ];
-        } else if (arg === 'on') {
-          onSoundSetRef.current?.(true);
-          outputLines = [
-            { content: 'Sound enabled.', type: 'output' },
-          ];
-        } else if (arg === 'off') {
-          onSoundSetRef.current?.(false);
-          outputLines = [
-            { content: 'Sound disabled.', type: 'output' },
-          ];
-        } else {
-          outputLines = [
-            { content: `Unknown option: ${arg}. Usage: sound <on|off>`, type: 'error' },
-          ];
-        }
-      } else if (trimmedCmd in commands) {
-        const output = commands[trimmedCmd as keyof typeof commands];
-        if (output.isHtml) {
-          Promise.all(output.map(line => sanitizeHtml(line))).then(sanitized => {
-            const htmlLines: TerminalLine[] = sanitized.map(content => ({
-              content,
-              type: 'output' as const,
-              isHtml: true,
-            }));
-            renderOutput(htmlLines, startTime, trimmedCmd, currentSpinnerId);
-          }).catch(() => {
-            const fallback: TerminalLine[] = output.map(line => ({
-              content: line.replace(/<[^>]*>/g, ''),
-              type: 'output' as const,
-            }));
-            renderOutput(fallback, startTime, trimmedCmd, currentSpinnerId);
-          });
-          return;
-        }
-        outputLines = output.map(line => ({
-          content: line,
-          type: 'output' as const,
-        }));
-      } else {
-        onBellRef.current?.();
-        playSoundRef.current?.('error');
-        outputLines = [{ content: `Command not found: ${cmd}`, type: 'error' as const }];
+      });
+
+      // HTML commands need async sanitization
+      if (result.isHtml) {
+        Promise.all(result.lines.map(l => sanitizeHtml(l.content))).then(sanitized => {
+          renderOutput(
+            sanitized.map(content => ({ content, type: 'output' as const, isHtml: true })),
+            startTime, trimmedCmd, currentSpinnerId,
+          );
+        }).catch(() => {
+          renderOutput(
+            result.lines.map(l => ({ ...l, content: l.content.replace(/<[^>]*>/g, '') })),
+            startTime, trimmedCmd, currentSpinnerId,
+          );
+        });
+        return;
       }
 
-      renderOutput(outputLines, startTime, trimmedCmd, currentSpinnerId);
+      renderOutput(result.lines, startTime, trimmedCmd, currentSpinnerId);
     }, 600);
     spinnerTimeouts.current.add(timeoutId);
   }, [cancelMotdAnimation, displayMotd, displayHelp, setTheme, reducedMotion]);

--- a/src/components/Terminal/Terminal.tsx
+++ b/src/components/Terminal/Terminal.tsx
@@ -338,7 +338,7 @@ const Terminal = ({ onShutdown, onBell, playSound, soundEnabled, onSoundSet, onR
   }, [cancelMotdAnimation, updateAutoSuggestion]);
 
   const handleInputFocus = useCallback(() => {
-    if (inputCommandRef.current.trim() === '') {
+    if (inputCommandRef.current.trim() === '' && !showSuggestionsRef.current) {
       setShowSuggestions(true);
       setSuggestionMode('commands');
       setSelectedSuggestionIndex(0);
@@ -616,7 +616,9 @@ const Terminal = ({ onShutdown, onBell, playSound, soundEnabled, onSoundSet, onR
       const history = commandHistoryRef.current;
       const newIndex = historyIndexRef.current + 1 >= history.length ? 0 : historyIndexRef.current + 1;
       setHistoryIndex(newIndex);
-      setInputCommand(history[history.length - 1 - newIndex]);
+      const cmd = history[history.length - 1 - newIndex];
+      inputCommandRef.current = cmd;
+      setInputCommand(cmd);
       setAutoSuggestion(null);
     }
   }, []);
@@ -629,7 +631,9 @@ const Terminal = ({ onShutdown, onBell, playSound, soundEnabled, onSoundSet, onR
       const history = commandHistoryRef.current;
       const newIndex = historyIndexRef.current <= 0 ? history.length - 1 : historyIndexRef.current - 1;
       setHistoryIndex(newIndex);
-      setInputCommand(history[history.length - 1 - newIndex]);
+      const cmd = history[history.length - 1 - newIndex];
+      inputCommandRef.current = cmd;
+      setInputCommand(cmd);
       setAutoSuggestion(null);
     }
   }, []);

--- a/src/components/Terminal/Terminal.tsx
+++ b/src/components/Terminal/Terminal.tsx
@@ -144,7 +144,6 @@ const Terminal = ({ onShutdown, onBell, playSound, soundEnabled, onSoundSet, onR
   const soundEnabledRef = useRef(soundEnabled);
   const isMobileRef = useRef(isMobile);
   const inputCommandRef = useRef(inputCommand);
-  const showSuggestionsRef = useRef(showSuggestions);
   const selectedSuggestionIndexRef = useRef(selectedSuggestionIndex);
   const suggestionModeRef = useRef(suggestionMode);
   const autoSuggestionRef = useRef(autoSuggestion);
@@ -156,7 +155,6 @@ const Terminal = ({ onShutdown, onBell, playSound, soundEnabled, onSoundSet, onR
   soundEnabledRef.current = soundEnabled;
   isMobileRef.current = isMobile;
   inputCommandRef.current = inputCommand;
-  showSuggestionsRef.current = showSuggestions;
   selectedSuggestionIndexRef.current = selectedSuggestionIndex;
   suggestionModeRef.current = suggestionMode;
   autoSuggestionRef.current = autoSuggestion;
@@ -194,6 +192,10 @@ const Terminal = ({ onShutdown, onBell, playSound, soundEnabled, onSoundSet, onR
 
   const filteredSuggestionsRef = useRef(filteredSuggestions);
   filteredSuggestionsRef.current = filteredSuggestions;
+
+  const suggestionsVisible = showSuggestions && filteredSuggestions.length > 0;
+  const suggestionsVisibleRef = useRef(suggestionsVisible);
+  suggestionsVisibleRef.current = suggestionsVisible;
 
   const hexBgStyle = useMemo(() => {
     const mask = 'radial-gradient(ellipse at 50% 45%, black 15%, transparent 65%)';
@@ -321,26 +323,14 @@ const Terminal = ({ onShutdown, onBell, playSound, soundEnabled, onSoundSet, onR
     updateAutoSuggestion(value);
 
     if (isMobileRef.current) {
-      const trimmed = value.trim().toLowerCase();
-      if (trimmed === '') {
-        setShowSuggestions(true);
-        setSuggestionMode('commands');
-        setSelectedSuggestionIndex(0);
-      } else {
-        const hasMatches = suggestions.some(s =>
-          s.command.toLowerCase().startsWith(trimmed)
-        );
-        setShowSuggestions(hasMatches);
-        if (hasMatches) {
-          setSuggestionMode('commands');
-          setSelectedSuggestionIndex(0);
-        }
-      }
+      setShowSuggestions(true);
+      setSuggestionMode('commands');
+      setSelectedSuggestionIndex(0);
     }
   }, [cancelMotdAnimation, updateAutoSuggestion]);
 
   const handleInputActivate = useCallback(() => {
-    if (inputCommandRef.current.trim() === '' && !showSuggestionsRef.current) {
+    if (inputCommandRef.current.trim() === '' && !suggestionsVisibleRef.current) {
       setShowSuggestions(true);
       setSuggestionMode('commands');
       setSelectedSuggestionIndex(0);
@@ -589,7 +579,7 @@ const Terminal = ({ onShutdown, onBell, playSound, soundEnabled, onSoundSet, onR
 
   const actionTab = useCallback(() => {
     cancelMotdAnimation();
-    if (showSuggestionsRef.current) {
+    if (suggestionsVisibleRef.current) {
       selectSuggestion(selectedSuggestionIndexRef.current);
     } else if (autoSuggestionRef.current) {
       completeAutoSuggestion();
@@ -602,7 +592,7 @@ const Terminal = ({ onShutdown, onBell, playSound, soundEnabled, onSoundSet, onR
   }, [cancelMotdAnimation, selectSuggestion, completeAutoSuggestion]);
 
   const actionUp = useCallback(() => {
-    if (showSuggestionsRef.current) {
+    if (suggestionsVisibleRef.current) {
       suppressHoverBriefly();
       const len = suggestionModeRef.current === 'themes' ? VALID_THEMES.length : filteredSuggestionsRef.current.length;
       setSelectedSuggestionIndex(prev => prev > 0 ? prev - 1 : len - 1);
@@ -618,7 +608,7 @@ const Terminal = ({ onShutdown, onBell, playSound, soundEnabled, onSoundSet, onR
   }, []);
 
   const actionDown = useCallback(() => {
-    if (showSuggestionsRef.current) {
+    if (suggestionsVisibleRef.current) {
       suppressHoverBriefly();
       const len = suggestionModeRef.current === 'themes' ? VALID_THEMES.length : filteredSuggestionsRef.current.length;
       setSelectedSuggestionIndex(prev => prev < len - 1 ? prev + 1 : 0);
@@ -634,7 +624,7 @@ const Terminal = ({ onShutdown, onBell, playSound, soundEnabled, onSoundSet, onR
   }, []);
 
   const actionEnter = useCallback(() => {
-    if (showSuggestionsRef.current && inputCommandRef.current.trim() === '') {
+    if (suggestionsVisibleRef.current && inputCommandRef.current.trim() === '') {
       selectSuggestion(selectedSuggestionIndexRef.current);
     } else {
       setShowSuggestions(false);
@@ -678,9 +668,9 @@ const Terminal = ({ onShutdown, onBell, playSound, soundEnabled, onSoundSet, onR
         }
         return;
       case 'Escape':
-        if (showSuggestionsRef.current && suggestionModeRef.current === 'themes') {
+        if (suggestionsVisibleRef.current && suggestionModeRef.current === 'themes') {
           backToCommands();
-        } else if (showSuggestionsRef.current) {
+        } else if (suggestionsVisibleRef.current) {
           setShowSuggestions(false);
           setSelectedSuggestionIndex(0);
         } else {
@@ -863,14 +853,14 @@ const Terminal = ({ onShutdown, onBell, playSound, soundEnabled, onSoundSet, onR
           autoSuggestion={autoSuggestion}
           isInputBlocked={isInputBlocked}
           isMobile={isMobile}
-          showSuggestions={showSuggestions}
+          showSuggestions={suggestionsVisible}
           onInputChange={handleInputChange}
           onKeyDown={handleKeyDown}
           onInputClick={isMobile ? handleInputActivate : undefined}
           onFocus={isMobile ? handleInputActivate : undefined}
           inputRef={inputRef}
         />
-        {showSuggestions && (
+        {suggestionsVisible && (
           <Suggestions
             ref={suggestionsRef}
             suggestions={filteredSuggestions}

--- a/src/components/Terminal/Terminal.tsx
+++ b/src/components/Terminal/Terminal.tsx
@@ -314,22 +314,22 @@ const Terminal = ({ onShutdown, onBell, playSound, soundEnabled, onSoundSet, onR
     playSoundRef.current?.('keypress');
     updateAutoSuggestion(value);
 
-    // Show/hide suggestions based on input
-    const trimmed = value.trim().toLowerCase();
-    if (trimmed === '') {
-      // Backspaced to empty — re-open full list
-      setShowSuggestions(true);
-      setSuggestionMode('commands');
-      setSelectedSuggestionIndex(0);
-    } else {
-      // Check if any commands match
-      const hasMatches = suggestions.some(s =>
-        s.command.toLowerCase().startsWith(trimmed)
-      );
-      setShowSuggestions(hasMatches);
-      if (hasMatches) {
+    // Show/hide mobile suggestion dropdown based on input
+    if (isMobileRef.current) {
+      const trimmed = value.trim().toLowerCase();
+      if (trimmed === '') {
+        setShowSuggestions(true);
         setSuggestionMode('commands');
         setSelectedSuggestionIndex(0);
+      } else {
+        const hasMatches = suggestions.some(s =>
+          s.command.toLowerCase().startsWith(trimmed)
+        );
+        setShowSuggestions(hasMatches);
+        if (hasMatches) {
+          setSuggestionMode('commands');
+          setSelectedSuggestionIndex(0);
+        }
       }
     }
   }, [cancelMotdAnimation, updateAutoSuggestion]);
@@ -588,7 +588,7 @@ const Terminal = ({ onShutdown, onBell, playSound, soundEnabled, onSoundSet, onR
       selectSuggestion(selectedSuggestionIndexRef.current);
     } else if (autoSuggestionRef.current) {
       completeAutoSuggestion();
-    } else {
+    } else if (isMobileRef.current) {
       setSuggestionMode('commands');
       setShowSuggestions(true);
       setSelectedSuggestionIndex(0);

--- a/src/components/Terminal/Terminal.tsx
+++ b/src/components/Terminal/Terminal.tsx
@@ -314,7 +314,6 @@ const Terminal = ({ onShutdown, onBell, playSound, soundEnabled, onSoundSet, onR
     playSoundRef.current?.('keypress');
     updateAutoSuggestion(value);
 
-    // Show/hide mobile suggestion dropdown based on input
     if (isMobileRef.current) {
       const trimmed = value.trim().toLowerCase();
       if (trimmed === '') {

--- a/src/components/Terminal/Terminal.tsx
+++ b/src/components/Terminal/Terminal.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect, useRef, useImperativeHandle, useMemo, useCallback, ChangeEvent, KeyboardEvent, Ref } from 'react';
+import { useState, useEffect, useRef, useMemo, useCallback, ChangeEvent, KeyboardEvent } from 'react';
 import type DOMPurifyType from 'dompurify';
 import { suggestions } from './commands';
 import { Volume2, VolumeX } from 'lucide-react';
@@ -73,22 +73,16 @@ const sanitizeHtml = async (content: string): Promise<string> => {
   return purifyInstance.sanitize(content, PURIFY_CONFIG);
 };
 
-export type TerminalHandle = {
-  handleMobileAction: (action: 'up' | 'down') => void;
-};
-
 type TerminalProps = {
   onShutdown?: () => void;
   onBell?: () => void;
   playSound?: (sound: SoundType) => void;
   soundEnabled?: boolean;
   onSoundSet?: (enabled: boolean) => void;
-  onRevealStateChange?: (isRevealing: boolean) => void;
   bootComplete?: boolean;
-  ref?: Ref<TerminalHandle>;
 };
 
-const Terminal = ({ onShutdown, onBell, playSound, soundEnabled, onSoundSet, onRevealStateChange, bootComplete, ref }: TerminalProps) => {
+const Terminal = ({ onShutdown, onBell, playSound, soundEnabled, onSoundSet, bootComplete }: TerminalProps) => {
   const isMobile = useIsMobile();
   const promptPrefix = '~ $ ';
   const { theme, setTheme } = useTheme();
@@ -555,17 +549,6 @@ const Terminal = ({ onShutdown, onBell, playSound, soundEnabled, onSoundSet, onR
     }
   }, [selectSuggestion, handleCommand]);
 
-  useImperativeHandle(ref, () => ({
-    handleMobileAction: (action: 'up' | 'down') => {
-      if (isInputBlockedRef.current) return;
-      switch (action) {
-        case 'up': actionUp(); break;
-        case 'down': actionDown(); break;
-      }
-      inputRef.current?.focus();
-    },
-  }), [actionUp, actionDown]);
-
   const handleKeyDown = useCallback((e: KeyboardEvent) => {
     if (isInputBlockedRef.current) { e.preventDefault(); return; }
     switch (e.key) {
@@ -624,8 +607,7 @@ const Terminal = ({ onShutdown, onBell, playSound, soundEnabled, onSoundSet, onR
       if (
         suggestionsRef.current &&
         !suggestionsRef.current.contains(target) &&
-        !inputRef.current?.contains(target) &&
-        !target.closest('[data-mobile-action]')
+        !inputRef.current?.contains(target)
       ) {
         setShowSuggestions(false);
         setSuggestionMode('commands');
@@ -744,10 +726,6 @@ const Terminal = ({ onShutdown, onBell, playSound, soundEnabled, onSoundSet, onR
     revealRafRef.current = requestAnimationFrame(step);
     return () => cancelAnimationFrame(revealRafRef.current);
   }, [revealingLines]);
-
-  useEffect(() => {
-    onRevealStateChange?.(isInputBlocked);
-  }, [revealingLines, onRevealStateChange]);
 
   return (
     <section ref={sectionRef} className="w-full flex flex-col flex-1 overflow-hidden p-4 terminal-glow crt-breathe" style={{ background: 'var(--terminal-bg)' }}>

--- a/src/components/Terminal/Terminal.tsx
+++ b/src/components/Terminal/Terminal.tsx
@@ -816,6 +816,7 @@ const Terminal = ({ onShutdown, onBell, playSound, soundEnabled, onSoundSet, onR
           autoSuggestion={autoSuggestion}
           isInputBlocked={isInputBlocked}
           isMobile={isMobile}
+          showSuggestions={showSuggestions}
           onInputChange={handleInputChange}
           onKeyDown={handleKeyDown}
           inputRef={inputRef}

--- a/src/components/Terminal/Terminal.tsx
+++ b/src/components/Terminal/Terminal.tsx
@@ -90,7 +90,7 @@ const RESPONSIVE_COMMANDS: Record<string, { mobile: string; desktop: string }> =
 };
 
 export type TerminalHandle = {
-  handleMobileAction: (action: 'tab' | 'up' | 'down' | 'enter') => void;
+  handleMobileAction: (action: 'up' | 'down') => void;
 };
 
 type TerminalProps = {
@@ -594,17 +594,15 @@ const Terminal = ({ onShutdown, onBell, playSound, soundEnabled, onSoundSet, onR
   }, [selectSuggestion, handleCommand]);
 
   useImperativeHandle(ref, () => ({
-    handleMobileAction: (action: 'tab' | 'up' | 'down' | 'enter') => {
+    handleMobileAction: (action: 'up' | 'down') => {
       if (isInputBlockedRef.current) return;
       switch (action) {
-        case 'tab': actionTab(); break;
         case 'up': actionUp(); break;
         case 'down': actionDown(); break;
-        case 'enter': actionEnter(); break;
       }
       inputRef.current?.focus();
     },
-  }), [actionTab, actionUp, actionDown, actionEnter]);
+  }), [actionUp, actionDown]);
 
   const handleKeyDown = useCallback((e: KeyboardEvent) => {
     if (isInputBlockedRef.current) { e.preventDefault(); return; }

--- a/src/components/Terminal/Terminal.tsx
+++ b/src/components/Terminal/Terminal.tsx
@@ -587,7 +587,7 @@ const Terminal = ({ onShutdown, onBell, playSound, soundEnabled, onSoundSet, onR
       selectSuggestion(selectedSuggestionIndexRef.current);
     } else if (autoSuggestionRef.current) {
       completeAutoSuggestion();
-    } else if (isMobileRef.current) {
+    } else {
       setSuggestionMode('commands');
       setShowSuggestions(true);
       setSelectedSuggestionIndex(0);

--- a/src/components/Terminal/Terminal.tsx
+++ b/src/components/Terminal/Terminal.tsx
@@ -189,9 +189,6 @@ const Terminal = ({ onShutdown, onBell, playSound, soundEnabled, onSoundSet, onR
   const filteredSuggestionsRef = useRef(filteredSuggestions);
   filteredSuggestionsRef.current = filteredSuggestions;
 
-  const filteredLengthRef = useRef(filteredSuggestions.length);
-  filteredLengthRef.current = filteredSuggestions.length;
-
   const hexBgStyle = useMemo(() => {
     const mask = 'radial-gradient(ellipse at 50% 45%, black 15%, transparent 65%)';
     return {
@@ -337,15 +334,7 @@ const Terminal = ({ onShutdown, onBell, playSound, soundEnabled, onSoundSet, onR
     }
   }, [cancelMotdAnimation, updateAutoSuggestion]);
 
-  const handleInputFocus = useCallback(() => {
-    if (inputCommandRef.current.trim() === '' && !showSuggestionsRef.current) {
-      setShowSuggestions(true);
-      setSuggestionMode('commands');
-      setSelectedSuggestionIndex(0);
-    }
-  }, []);
-
-  const handleInputClick = useCallback(() => {
+  const handleInputActivate = useCallback(() => {
     if (inputCommandRef.current.trim() === '' && !showSuggestionsRef.current) {
       setShowSuggestions(true);
       setSuggestionMode('commands');
@@ -610,7 +599,7 @@ const Terminal = ({ onShutdown, onBell, playSound, soundEnabled, onSoundSet, onR
 
   const actionUp = useCallback(() => {
     if (showSuggestionsRef.current) {
-      const len = suggestionModeRef.current === 'themes' ? VALID_THEMES.length : filteredLengthRef.current;
+      const len = suggestionModeRef.current === 'themes' ? VALID_THEMES.length : filteredSuggestionsRef.current.length;
       setSelectedSuggestionIndex(prev => prev > 0 ? prev - 1 : len - 1);
     } else if (commandHistoryRef.current.length > 0) {
       const history = commandHistoryRef.current;
@@ -625,7 +614,7 @@ const Terminal = ({ onShutdown, onBell, playSound, soundEnabled, onSoundSet, onR
 
   const actionDown = useCallback(() => {
     if (showSuggestionsRef.current) {
-      const len = suggestionModeRef.current === 'themes' ? VALID_THEMES.length : filteredLengthRef.current;
+      const len = suggestionModeRef.current === 'themes' ? VALID_THEMES.length : filteredSuggestionsRef.current.length;
       setSelectedSuggestionIndex(prev => prev < len - 1 ? prev + 1 : 0);
     } else if (commandHistoryRef.current.length > 0) {
       const history = commandHistoryRef.current;
@@ -871,8 +860,8 @@ const Terminal = ({ onShutdown, onBell, playSound, soundEnabled, onSoundSet, onR
           showSuggestions={showSuggestions}
           onInputChange={handleInputChange}
           onKeyDown={handleKeyDown}
-          onInputClick={isMobile ? handleInputClick : undefined}
-          onFocus={isMobile ? handleInputFocus : undefined}
+          onInputClick={isMobile ? handleInputActivate : undefined}
+          onFocus={isMobile ? handleInputActivate : undefined}
           inputRef={inputRef}
         />
         {showSuggestions && (

--- a/src/components/Terminal/Terminal.tsx
+++ b/src/components/Terminal/Terminal.tsx
@@ -234,12 +234,12 @@ const Terminal = ({ onShutdown, onBell, playSound, soundEnabled, onSoundSet, onR
 
   // Plain-text MOTD hints (used by typing animation; HTML version derived below)
   const motdPlainText = isMobile
-    ? 'Tap \u2261 to explore commands.'
+    ? "Type 'help' or tap the prompt to explore."
     : "Type 'help' or press Tab to explore.";
 
   const displayMotd = useCallback((): TerminalLine[] => {
     const hint = isMobileRef.current
-      ? 'Tap <span style="color: var(--terminal-primary)">≡</span> to explore commands.'
+      ? 'Type <span style="color: var(--terminal-primary)">\'help\'</span> or <span style="color: var(--terminal-primary)">tap the prompt</span> to explore.'
       : 'Type <span style="color: var(--terminal-primary)">\'help\'</span> or press <span style="color: var(--terminal-primary)">Tab</span> to explore.';
     return [
       { content: `<span style="color: var(--terminal-gray)">${hint}</span>`, type: 'output' as const, isHtml: true },

--- a/src/components/Terminal/Terminal.tsx
+++ b/src/components/Terminal/Terminal.tsx
@@ -120,6 +120,12 @@ const Terminal = ({ onShutdown, onBell, playSound, soundEnabled, onSoundSet, onR
   const terminalRef = useRef<HTMLDivElement>(null);
   const suggestionsRef = useRef<HTMLDivElement>(null);
   const suppressHoverRef = useRef(false);
+  const suppressHoverTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const suppressHoverBriefly = () => {
+    suppressHoverRef.current = true;
+    if (suppressHoverTimerRef.current) clearTimeout(suppressHoverTimerRef.current);
+    suppressHoverTimerRef.current = setTimeout(() => { suppressHoverRef.current = false; }, 100);
+  };
   const spinnerTimeouts = useRef(new Set<ReturnType<typeof setTimeout>>());
   const spinnerIdRef = useRef(0);
   const motdDelayRef = useRef<ReturnType<typeof setTimeout> | null>(null);
@@ -591,15 +597,13 @@ const Terminal = ({ onShutdown, onBell, playSound, soundEnabled, onSoundSet, onR
       setSuggestionMode('commands');
       setShowSuggestions(true);
       setSelectedSuggestionIndex(0);
-      suppressHoverRef.current = true;
-      setTimeout(() => { suppressHoverRef.current = false; }, 100);
+      suppressHoverBriefly();
     }
   }, [cancelMotdAnimation, selectSuggestion, completeAutoSuggestion]);
 
   const actionUp = useCallback(() => {
     if (showSuggestionsRef.current) {
-      suppressHoverRef.current = true;
-      setTimeout(() => { suppressHoverRef.current = false; }, 100);
+      suppressHoverBriefly();
       const len = suggestionModeRef.current === 'themes' ? VALID_THEMES.length : filteredSuggestionsRef.current.length;
       setSelectedSuggestionIndex(prev => prev > 0 ? prev - 1 : len - 1);
     } else if (commandHistoryRef.current.length > 0) {
@@ -615,8 +619,7 @@ const Terminal = ({ onShutdown, onBell, playSound, soundEnabled, onSoundSet, onR
 
   const actionDown = useCallback(() => {
     if (showSuggestionsRef.current) {
-      suppressHoverRef.current = true;
-      setTimeout(() => { suppressHoverRef.current = false; }, 100);
+      suppressHoverBriefly();
       const len = suggestionModeRef.current === 'themes' ? VALID_THEMES.length : filteredSuggestionsRef.current.length;
       setSelectedSuggestionIndex(prev => prev < len - 1 ? prev + 1 : 0);
     } else if (commandHistoryRef.current.length > 0) {

--- a/src/components/Terminal/Terminal.tsx
+++ b/src/components/Terminal/Terminal.tsx
@@ -867,8 +867,8 @@ const Terminal = ({ onShutdown, onBell, playSound, soundEnabled, onSoundSet, onR
           showSuggestions={showSuggestions}
           onInputChange={handleInputChange}
           onKeyDown={handleKeyDown}
-          onInputClick={handleInputClick}
-          onFocus={handleInputFocus}
+          onInputClick={isMobile ? handleInputClick : undefined}
+          onFocus={isMobile ? handleInputFocus : undefined}
           inputRef={inputRef}
         />
         {showSuggestions && (

--- a/src/components/Terminal/Terminal.tsx
+++ b/src/components/Terminal/Terminal.tsx
@@ -177,6 +177,21 @@ const Terminal = ({ onShutdown, onBell, playSound, soundEnabled, onSoundSet, onR
       : s
   ), [soundEnabled]);
 
+  const filteredSuggestions = useMemo(() => {
+    if (suggestionMode === 'themes') return displaySuggestions;
+    const trimmed = inputCommand.trim().toLowerCase();
+    if (!trimmed) return displaySuggestions;
+    return displaySuggestions.filter(s =>
+      s.command.toLowerCase().startsWith(trimmed)
+    );
+  }, [displaySuggestions, inputCommand, suggestionMode]);
+
+  const filteredSuggestionsRef = useRef(filteredSuggestions);
+  filteredSuggestionsRef.current = filteredSuggestions;
+
+  const filteredLengthRef = useRef(filteredSuggestions.length);
+  filteredLengthRef.current = filteredSuggestions.length;
+
   const hexBgStyle = useMemo(() => {
     const mask = 'radial-gradient(ellipse at 50% 45%, black 15%, transparent 65%)';
     return {
@@ -301,13 +316,47 @@ const Terminal = ({ onShutdown, onBell, playSound, soundEnabled, onSoundSet, onR
     setInputCommand(value);
     playSoundRef.current?.('keypress');
     updateAutoSuggestion(value);
-    setShowSuggestions(false);
-    setSuggestionMode('commands');
+
+    // Show/hide suggestions based on input
+    const trimmed = value.trim().toLowerCase();
+    if (trimmed === '') {
+      // Backspaced to empty — re-open full list
+      setShowSuggestions(true);
+      setSuggestionMode('commands');
+      setSelectedSuggestionIndex(0);
+    } else {
+      // Check if any commands match
+      const hasMatches = suggestions.some(s =>
+        s.command.toLowerCase().startsWith(trimmed)
+      );
+      setShowSuggestions(hasMatches);
+      if (hasMatches) {
+        setSuggestionMode('commands');
+        setSelectedSuggestionIndex(0);
+      }
+    }
   }, [cancelMotdAnimation, updateAutoSuggestion]);
+
+  const handleInputFocus = useCallback(() => {
+    if (inputCommandRef.current.trim() === '') {
+      setShowSuggestions(true);
+      setSuggestionMode('commands');
+      setSelectedSuggestionIndex(0);
+    }
+  }, []);
+
+  const handleInputClick = useCallback(() => {
+    if (inputCommandRef.current.trim() === '' && !showSuggestionsRef.current) {
+      setShowSuggestions(true);
+      setSuggestionMode('commands');
+      setSelectedSuggestionIndex(0);
+    }
+  }, []);
 
   const handleCommand = useCallback((cmd: string) => {
     if (isInputBlockedRef.current) return;
     cancelMotdAnimation();
+    setShowSuggestions(false);
     const trimmedCmd = cmd.trim().toLowerCase();
 
     if (trimmedCmd === '') return;
@@ -517,7 +566,7 @@ const Terminal = ({ onShutdown, onBell, playSound, soundEnabled, onSoundSet, onR
 
   const selectSuggestion = useCallback((index: number) => {
     if (suggestionModeRef.current === 'commands') {
-      const selectedCommand = suggestions[index].command;
+      const selectedCommand = filteredSuggestionsRef.current[index].command;
       if (selectedCommand === 'theme') {
         setSuggestionMode('themes');
         setSelectedSuggestionIndex(0);
@@ -561,7 +610,7 @@ const Terminal = ({ onShutdown, onBell, playSound, soundEnabled, onSoundSet, onR
 
   const actionUp = useCallback(() => {
     if (showSuggestionsRef.current) {
-      const len = suggestionModeRef.current === 'themes' ? VALID_THEMES.length : suggestions.length;
+      const len = suggestionModeRef.current === 'themes' ? VALID_THEMES.length : filteredLengthRef.current;
       setSelectedSuggestionIndex(prev => prev > 0 ? prev - 1 : len - 1);
     } else if (commandHistoryRef.current.length > 0) {
       const history = commandHistoryRef.current;
@@ -574,7 +623,7 @@ const Terminal = ({ onShutdown, onBell, playSound, soundEnabled, onSoundSet, onR
 
   const actionDown = useCallback(() => {
     if (showSuggestionsRef.current) {
-      const len = suggestionModeRef.current === 'themes' ? VALID_THEMES.length : suggestions.length;
+      const len = suggestionModeRef.current === 'themes' ? VALID_THEMES.length : filteredLengthRef.current;
       setSelectedSuggestionIndex(prev => prev < len - 1 ? prev + 1 : 0);
     } else if (commandHistoryRef.current.length > 0) {
       const history = commandHistoryRef.current;
@@ -586,9 +635,10 @@ const Terminal = ({ onShutdown, onBell, playSound, soundEnabled, onSoundSet, onR
   }, []);
 
   const actionEnter = useCallback(() => {
-    if (showSuggestionsRef.current) {
+    if (showSuggestionsRef.current && inputCommandRef.current.trim() === '') {
       selectSuggestion(selectedSuggestionIndexRef.current);
     } else {
+      setShowSuggestions(false);
       handleCommand(inputCommandRef.current);
     }
   }, [selectSuggestion, handleCommand]);
@@ -817,12 +867,14 @@ const Terminal = ({ onShutdown, onBell, playSound, soundEnabled, onSoundSet, onR
           showSuggestions={showSuggestions}
           onInputChange={handleInputChange}
           onKeyDown={handleKeyDown}
+          onInputClick={handleInputClick}
+          onFocus={handleInputFocus}
           inputRef={inputRef}
         />
         {showSuggestions && (
           <Suggestions
             ref={suggestionsRef}
-            suggestions={displaySuggestions}
+            suggestions={filteredSuggestions}
             selectedIndex={selectedSuggestionIndex}
             onSelect={selectSuggestion}
             onMouseEnter={handleSuggestionMouseEnter}
@@ -830,6 +882,7 @@ const Terminal = ({ onShutdown, onBell, playSound, soundEnabled, onSoundSet, onR
             themes={VALID_THEMES}
             currentTheme={theme}
             onBack={backToCommands}
+            filterText={inputCommand.trim()}
           />
         )}
       </div>

--- a/src/components/Terminal/TerminalInput.tsx
+++ b/src/components/Terminal/TerminalInput.tsx
@@ -43,6 +43,7 @@ const TerminalInput = memo(({
           style={{ color: 'var(--terminal-primary)' }}
           inputMode={isMobile ? "search" : undefined}
           aria-expanded={showSuggestions}
+          aria-controls={showSuggestions ? "terminal-suggestions" : undefined}
           onClick={onInputClick}
           onFocus={onFocus}
           autoCapitalize="none"

--- a/src/components/Terminal/TerminalInput.tsx
+++ b/src/components/Terminal/TerminalInput.tsx
@@ -6,8 +6,11 @@ interface TerminalInputProps {
   autoSuggestion: string | null;
   isInputBlocked: boolean;
   isMobile: boolean;
+  showSuggestions: boolean;
   onInputChange: (e: ChangeEvent<HTMLInputElement>) => void;
   onKeyDown: (e: KeyboardEvent) => void;
+  onInputClick?: () => void;
+  onFocus?: () => void;
   inputRef: Ref<HTMLInputElement>;
 }
 
@@ -16,8 +19,11 @@ const TerminalInput = memo(({
   autoSuggestion,
   isInputBlocked,
   isMobile,
+  showSuggestions,
   onInputChange,
   onKeyDown,
+  onInputClick,
+  onFocus,
   inputRef,
 }: TerminalInputProps) => {
   return (
@@ -35,7 +41,10 @@ const TerminalInput = memo(({
           onKeyDown={onKeyDown}
           className="bg-transparent font-mono text-sm w-full focus:outline-none relative z-10 caret-transparent"
           style={{ color: 'var(--terminal-primary)' }}
-          inputMode={isMobile ? "none" : undefined}
+          inputMode={isMobile ? "search" : undefined}
+          aria-expanded={showSuggestions}
+          onClick={onInputClick}
+          onFocus={onFocus}
           autoCapitalize="none"
           spellCheck={false}
           autoComplete="off"

--- a/src/components/Terminal/TerminalOutput.tsx
+++ b/src/components/Terminal/TerminalOutput.tsx
@@ -22,6 +22,8 @@ const TerminalOutput = memo(({
 }: TerminalOutputProps) => {
   return (
     <div
+      role="log"
+      aria-live="polite"
       ref={scrollRef}
       className="h-full overflow-y-auto overflow-x-hidden text-sm terminal-scroll relative z-[1]"
       style={{

--- a/src/components/Terminal/__tests__/Suggestions.test.tsx
+++ b/src/components/Terminal/__tests__/Suggestions.test.tsx
@@ -16,7 +16,7 @@ const defaultProps = {
 
 
 describe('Suggestions', () => {
-  it('renders all 11 command suggestions in commands mode', () => {
+  it('renders all 10 command suggestions in commands mode', () => {
     render(<Suggestions {...defaultProps} />);
     for (const s of suggestions) {
       expect(screen.getByText(s.command)).toBeInTheDocument();

--- a/src/components/Terminal/__tests__/Suggestions.test.tsx
+++ b/src/components/Terminal/__tests__/Suggestions.test.tsx
@@ -14,6 +14,8 @@ const defaultProps = {
   onBack: vi.fn(),
 };
 
+const baseProps = defaultProps;
+
 describe('Suggestions', () => {
   it('renders all 11 command suggestions in commands mode', () => {
     render(<Suggestions {...defaultProps} />);
@@ -45,5 +47,29 @@ describe('Suggestions', () => {
     render(<Suggestions {...defaultProps} onSelect={onSelect} />);
     fireEvent.click(screen.getByText('whoami'));
     expect(onSelect).toHaveBeenCalledWith(0);
+  });
+
+  it('has role="listbox" on the container', () => {
+    render(<Suggestions {...baseProps} />);
+    expect(screen.getByRole('listbox')).toBeInTheDocument();
+  });
+
+  it('has role="option" on each suggestion item', () => {
+    render(<Suggestions {...baseProps} />);
+    const options = screen.getAllByRole('option');
+    expect(options.length).toBe(baseProps.suggestions.length);
+  });
+
+  it('sets aria-label="Run <command>" on each item', () => {
+    render(<Suggestions {...baseProps} />);
+    const options = screen.getAllByRole('option');
+    expect(options[0]).toHaveAttribute('aria-label', `Run ${baseProps.suggestions[0].command}`);
+  });
+
+  it('highlights matching prefix when filterText is provided', () => {
+    render(<Suggestions {...baseProps} filterText="sk" />);
+    const option = screen.getByRole('option', { name: /Run skills/ });
+    const highlight = option.querySelector('[data-highlight="match"]');
+    expect(highlight).toHaveTextContent('sk');
   });
 });

--- a/src/components/Terminal/__tests__/Suggestions.test.tsx
+++ b/src/components/Terminal/__tests__/Suggestions.test.tsx
@@ -14,7 +14,6 @@ const defaultProps = {
   onBack: vi.fn(),
 };
 
-const baseProps = defaultProps;
 
 describe('Suggestions', () => {
   it('renders all 11 command suggestions in commands mode', () => {
@@ -50,24 +49,24 @@ describe('Suggestions', () => {
   });
 
   it('has role="listbox" on the container', () => {
-    render(<Suggestions {...baseProps} />);
+    render(<Suggestions {...defaultProps} />);
     expect(screen.getByRole('listbox')).toBeInTheDocument();
   });
 
   it('has role="option" on each suggestion item', () => {
-    render(<Suggestions {...baseProps} />);
+    render(<Suggestions {...defaultProps} />);
     const options = screen.getAllByRole('option');
-    expect(options.length).toBe(baseProps.suggestions.length);
+    expect(options.length).toBe(defaultProps.suggestions.length);
   });
 
   it('sets aria-label="Run <command>" on each item', () => {
-    render(<Suggestions {...baseProps} />);
+    render(<Suggestions {...defaultProps} />);
     const options = screen.getAllByRole('option');
-    expect(options[0]).toHaveAttribute('aria-label', `Run ${baseProps.suggestions[0].command}`);
+    expect(options[0]).toHaveAttribute('aria-label', `Run ${defaultProps.suggestions[0].command}`);
   });
 
   it('highlights matching prefix when filterText is provided', () => {
-    render(<Suggestions {...baseProps} filterText="sk" />);
+    render(<Suggestions {...defaultProps} filterText="sk" />);
     const option = screen.getByRole('option', { name: /Run skills/ });
     const highlight = option.querySelector('[data-highlight="match"]');
     expect(highlight).toHaveTextContent('sk');

--- a/src/components/Terminal/__tests__/Terminal.test.tsx
+++ b/src/components/Terminal/__tests__/Terminal.test.tsx
@@ -83,8 +83,7 @@ describe('Terminal', () => {
   it('renders contact output as HTML with links', async () => {
     renderWithProviders(<Terminal {...defaultProps} />);
     submitCommand('contact');
-    // DOMPurify is lazy-loaded — two flushes needed: first fires the 600ms timeout,
-    // second resolves the dynamic import() promise after suggestion state transitions
+    // DOMPurify is lazy-loaded — two flushes needed: timeout then dynamic import()
     await act(async () => { await vi.advanceTimersByTimeAsync(600); });
     await act(async () => { await vi.advanceTimersByTimeAsync(0); });
     const link = screen.getByText('github.com/dkoval');

--- a/src/components/Terminal/__tests__/Terminal.test.tsx
+++ b/src/components/Terminal/__tests__/Terminal.test.tsx
@@ -77,8 +77,10 @@ describe('Terminal', () => {
   it('renders contact output as HTML with links', async () => {
     renderWithProviders(<Terminal {...defaultProps} />);
     submitCommand('contact');
-    // DOMPurify is lazy-loaded — advanceTimersByTimeAsync flushes microtasks
+    // DOMPurify is lazy-loaded — two flushes needed: first fires the 600ms timeout,
+    // second resolves the dynamic import() promise after suggestion state transitions
     await act(async () => { await vi.advanceTimersByTimeAsync(600); });
+    await act(async () => { await vi.advanceTimersByTimeAsync(0); });
     const link = screen.getByText('github.com/dkoval');
     expect(link.closest('a')).toHaveAttribute('href', 'https://github.com/dkoval');
   });
@@ -170,6 +172,52 @@ describe('Terminal', () => {
     expect(bg).toBeInTheDocument();
     // Default theme is 'green' — radial gradient uses green RGB
     expect(bg!.style.backgroundImage).toContain('0, 255, 65');
+  });
+});
+
+describe('suggestion filtering (mobile)', () => {
+  beforeEach(() => {
+    setupTerminalMedia(true); // mobile mode
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('shows suggestions when input is focused and empty', async () => {
+    const { container } = renderWithProviders(<Terminal {...defaultProps} />);
+    const input = container.querySelector('input');
+    fireEvent.focus(input!);
+    expect(screen.getByRole('listbox')).toBeInTheDocument();
+  });
+
+  it('filters suggestions by prefix as user types', async () => {
+    const { container } = renderWithProviders(<Terminal {...defaultProps} />);
+    const input = container.querySelector('input');
+    fireEvent.focus(input!);
+    fireEvent.change(input!, { target: { value: 'sk' } });
+    const options = screen.getAllByRole('option');
+    expect(options).toHaveLength(1);
+    expect(options[0]).toHaveAttribute('aria-label', 'Run skills');
+  });
+
+  it('re-opens full list when input is backspaced to empty', async () => {
+    const { container } = renderWithProviders(<Terminal {...defaultProps} />);
+    const input = container.querySelector('input');
+    fireEvent.focus(input!);
+    fireEvent.change(input!, { target: { value: 's' } });
+    fireEvent.change(input!, { target: { value: '' } });
+    const options = screen.getAllByRole('option');
+    expect(options.length).toBeGreaterThan(1);
+  });
+
+  it('hides suggestions when no commands match', async () => {
+    const { container } = renderWithProviders(<Terminal {...defaultProps} />);
+    const input = container.querySelector('input');
+    fireEvent.focus(input!);
+    fireEvent.change(input!, { target: { value: 'xyz' } });
+    expect(screen.queryByRole('listbox')).not.toBeInTheDocument();
   });
 });
 

--- a/src/components/Terminal/__tests__/Terminal.test.tsx
+++ b/src/components/Terminal/__tests__/Terminal.test.tsx
@@ -1,4 +1,4 @@
-import { screen, fireEvent, act, waitFor } from '@testing-library/react';
+import { screen, fireEvent, act } from '@testing-library/react';
 import Terminal, { appendOutput, MAX_OUTPUT } from '../Terminal';
 import { TerminalLine } from '../types';
 import { renderWithProviders, mockMatchMedia } from '../../../test/helpers';

--- a/src/components/Terminal/__tests__/Terminal.test.tsx
+++ b/src/components/Terminal/__tests__/Terminal.test.tsx
@@ -1,4 +1,4 @@
-import { screen, fireEvent, act } from '@testing-library/react';
+import { screen, fireEvent, act, waitFor } from '@testing-library/react';
 import Terminal, { appendOutput, MAX_OUTPUT } from '../Terminal';
 import { TerminalLine } from '../types';
 import { renderWithProviders, mockMatchMedia } from '../../../test/helpers';
@@ -45,6 +45,12 @@ describe('Terminal', () => {
     expect(screen.getAllByText((_, el) =>
       el?.tagName === 'SPAN' && /Type.*'help'.*Tab.*explore/.test(el.textContent ?? '')
     ).length).toBeGreaterThan(0);
+  });
+
+  it('shows updated mobile MOTD', () => {
+    setupTerminalMedia(true); // mobile
+    const { container } = renderWithProviders(<Terminal {...defaultProps} />);
+    expect(container.textContent).toContain("Type 'help' or tap the prompt to explore.");
   });
 
   it('renders known command output after spinner delay', () => {
@@ -243,5 +249,13 @@ describe('appendOutput', () => {
     const existing = [makeLine('a'), makeLine('b')];
     const result = appendOutput(existing, makeLine('c'));
     expect(result).toHaveLength(3);
+  });
+
+  it('terminal output container has role="log" and aria-live="polite"', () => {
+    setupTerminalMedia(false);
+    const { container } = renderWithProviders(<Terminal {...defaultProps} />);
+    const log = container.querySelector('[role="log"]');
+    expect(log).toBeInTheDocument();
+    expect(log).toHaveAttribute('aria-live', 'polite');
   });
 });

--- a/src/components/Terminal/__tests__/Terminal.test.tsx
+++ b/src/components/Terminal/__tests__/Terminal.test.tsx
@@ -19,7 +19,6 @@ const defaultProps = {
   playSound: vi.fn(),
   soundEnabled: false,
   onSoundSet: vi.fn(),
-  onRevealStateChange: vi.fn(),
   bootComplete: true,
 };
 

--- a/src/components/Terminal/__tests__/TerminalInput.test.tsx
+++ b/src/components/Terminal/__tests__/TerminalInput.test.tsx
@@ -1,0 +1,46 @@
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import TerminalInput from '../TerminalInput';
+
+const baseProps = {
+  inputCommand: '',
+  inputRef: { current: null } as React.RefObject<HTMLInputElement | null>,
+  onInputChange: vi.fn(),
+  onKeyDown: vi.fn(),
+  isInputBlocked: false,
+  autoSuggestion: null,
+  isMobile: false,
+  showSuggestions: false,
+  onInputClick: vi.fn(),
+  onFocus: vi.fn(),
+};
+
+describe('TerminalInput', () => {
+  it('uses inputMode="search" on mobile', () => {
+    render(<TerminalInput {...baseProps} isMobile={true} />);
+    const input = screen.getByRole('textbox');
+    expect(input).toHaveAttribute('inputMode', 'search');
+  });
+
+  it('has no inputMode on desktop', () => {
+    render(<TerminalInput {...baseProps} isMobile={false} />);
+    const input = screen.getByRole('textbox');
+    expect(input).not.toHaveAttribute('inputMode');
+  });
+
+  it('sets aria-expanded based on showSuggestions prop', () => {
+    const { rerender } = render(<TerminalInput {...baseProps} showSuggestions={false} />);
+    const input = screen.getByRole('textbox');
+    expect(input).toHaveAttribute('aria-expanded', 'false');
+
+    rerender(<TerminalInput {...baseProps} showSuggestions={true} />);
+    expect(input).toHaveAttribute('aria-expanded', 'true');
+  });
+
+  it('calls onInputClick when input is clicked', () => {
+    const onInputClick = vi.fn();
+    render(<TerminalInput {...baseProps} onInputClick={onInputClick} />);
+    fireEvent.click(screen.getByRole('textbox'));
+    expect(onInputClick).toHaveBeenCalledOnce();
+  });
+});

--- a/src/components/Terminal/__tests__/commands.test.ts
+++ b/src/components/Terminal/__tests__/commands.test.ts
@@ -46,8 +46,8 @@ describe('commands registry', () => {
 });
 
 describe('suggestions', () => {
-  it('has exactly 11 entries', () => {
-    expect(suggestions).toHaveLength(11);
+  it('has exactly 10 entries', () => {
+    expect(suggestions).toHaveLength(10);
   });
 
   it('each entry has command, description, and icon', () => {
@@ -60,7 +60,7 @@ describe('suggestions', () => {
 
   const expectedCommands = [
     'whoami', 'man dmytro', 'skills', 'history', 'contact',
-    'uptime', 'theme', 'sound', 'help', 'clear', 'exit',
+    'theme', 'sound', 'help', 'clear', 'exit',
   ];
 
   it('contains all expected commands', () => {

--- a/src/components/Terminal/commandResolver.ts
+++ b/src/components/Terminal/commandResolver.ts
@@ -1,0 +1,119 @@
+import { commands } from './commands';
+import { TerminalLine } from './types';
+import { PAGE_LOAD_TIME, formatUptime, getCurrentTime } from '../../constants';
+import { ThemeName, VALID_THEMES } from '../../ThemeContext';
+
+const RESPONSIVE_COMMANDS: Record<string, { mobile: string; desktop: string }> = {
+  whoami: { mobile: 'whoami', desktop: 'whoamiDesktop' },
+  skills: { mobile: 'skillsMobile', desktop: 'skills' },
+};
+
+const THEME_EASTER_EGGS: Partial<Record<ThemeName, string>> = {
+  'tokyo-night': 'Welcome to Neo-Tokyo. The night shift begins.',
+  'one-dark-pro': 'Dark mode activated. Your eyes will thank you.',
+};
+
+export interface CommandContext {
+  isMobile: boolean;
+  theme: ThemeName;
+  soundEnabled: boolean;
+}
+
+export type CommandSideEffect =
+  | { type: 'setTheme'; theme: ThemeName }
+  | { type: 'setSoundEnabled'; enabled: boolean }
+  | { type: 'bell' };
+
+export interface CommandResult {
+  lines: TerminalLine[];
+  isHtml?: boolean;
+  effects?: CommandSideEffect[];
+}
+
+export function resolveCommand(cmd: string, ctx: CommandContext): CommandResult {
+  if (cmd in RESPONSIVE_COMMANDS) {
+    const variant = RESPONSIVE_COMMANDS[cmd];
+    const key = ctx.isMobile ? variant.mobile : variant.desktop;
+    return {
+      lines: commands[key].map(line => ({ content: line, type: 'output' as const })),
+    };
+  }
+
+  if (cmd === 'uptime') {
+    const seconds = Math.floor((Date.now() - PAGE_LOAD_TIME) / 1000);
+    const timeStr = getCurrentTime();
+    const base = (Date.now() % 100) / 100;
+    const load1 = (0.3 + base * 0.4).toFixed(2);
+    const load5 = (0.2 + base * 0.25).toFixed(2);
+    const load15 = (0.05 + base * 0.15).toFixed(2);
+    return {
+      lines: [{ content: ` ${timeStr} up ${formatUptime(seconds)},  1 user,  load average: ${load1}, ${load5}, ${load15}`, type: 'output' }],
+    };
+  }
+
+  if (cmd === 'theme' || cmd.startsWith('theme ')) {
+    const arg = cmd.replace('theme', '').trim();
+    if (!arg) {
+      return {
+        lines: [
+          { content: `Current theme: ${ctx.theme}`, type: 'output' },
+          { content: `Available: ${VALID_THEMES.join(', ')}`, type: 'output' },
+          { content: 'Usage: theme <name>', type: 'output' },
+        ],
+      };
+    }
+    if (VALID_THEMES.includes(arg as ThemeName)) {
+      const eggMessage = THEME_EASTER_EGGS[arg as ThemeName];
+      const eggKey = `dkoder-${arg}-seen`;
+      const isFirstTime = eggMessage && !localStorage.getItem(eggKey);
+      if (isFirstTime) localStorage.setItem(eggKey, '1');
+      return {
+        lines: [{ content: isFirstTime ? eggMessage! : `Theme switched to ${arg}.`, type: 'output' }],
+        effects: [{ type: 'setTheme', theme: arg as ThemeName }],
+      };
+    }
+    return {
+      lines: [{ content: `Unknown theme: ${arg}. Available: ${VALID_THEMES.join(', ')}`, type: 'error' }],
+    };
+  }
+
+  if (cmd === 'sound' || cmd.startsWith('sound ')) {
+    const arg = cmd.replace('sound', '').trim();
+    if (!arg) {
+      return {
+        lines: [
+          { content: `Sound: ${ctx.soundEnabled ? 'on' : 'off'}`, type: 'output' },
+          { content: 'Usage: sound <on|off>', type: 'output' },
+        ],
+      };
+    }
+    if (arg === 'on' || arg === 'off') {
+      const enabled = arg === 'on';
+      return {
+        lines: [{ content: enabled ? 'Sound enabled.' : 'Sound disabled.', type: 'output' }],
+        effects: [{ type: 'setSoundEnabled', enabled }],
+      };
+    }
+    return {
+      lines: [{ content: `Unknown option: ${arg}. Usage: sound <on|off>`, type: 'error' }],
+    };
+  }
+
+  if (cmd in commands) {
+    const output = commands[cmd as keyof typeof commands];
+    if (output.isHtml) {
+      return {
+        lines: output.map(line => ({ content: line, type: 'output' as const })),
+        isHtml: true,
+      };
+    }
+    return {
+      lines: output.map(line => ({ content: line, type: 'output' as const })),
+    };
+  }
+
+  return {
+    lines: [{ content: `Command not found: ${cmd}`, type: 'error' as const }],
+    effects: [{ type: 'bell' }],
+  };
+}

--- a/src/components/Terminal/commandResolver.ts
+++ b/src/components/Terminal/commandResolver.ts
@@ -1,6 +1,5 @@
 import { commands } from './commands';
 import { TerminalLine } from './types';
-import { PAGE_LOAD_TIME, formatUptime, getCurrentTime } from '../../constants';
 import { ThemeName, VALID_THEMES } from '../../ThemeContext';
 
 const RESPONSIVE_COMMANDS: Record<string, { mobile: string; desktop: string }> = {
@@ -36,18 +35,6 @@ export function resolveCommand(cmd: string, ctx: CommandContext): CommandResult 
     const key = ctx.isMobile ? variant.mobile : variant.desktop;
     return {
       lines: commands[key].map(line => ({ content: line, type: 'output' as const })),
-    };
-  }
-
-  if (cmd === 'uptime') {
-    const seconds = Math.floor((Date.now() - PAGE_LOAD_TIME) / 1000);
-    const timeStr = getCurrentTime();
-    const base = (Date.now() % 100) / 100;
-    const load1 = (0.3 + base * 0.4).toFixed(2);
-    const load5 = (0.2 + base * 0.25).toFixed(2);
-    const load15 = (0.05 + base * 0.15).toFixed(2);
-    return {
-      lines: [{ content: ` ${timeStr} up ${formatUptime(seconds)},  1 user,  load average: ${load1}, ${load5}, ${load15}`, type: 'output' }],
     };
   }
 

--- a/src/components/Terminal/commands.tsx
+++ b/src/components/Terminal/commands.tsx
@@ -1,4 +1,4 @@
-import { Cpu, Mail, Sparkles, User, Info, Clock, LogOut, History, Palette, Volume2, HelpCircle } from 'lucide-react';
+import { Cpu, Mail, Sparkles, User, Info, LogOut, History, Palette, Volume2, HelpCircle } from 'lucide-react';
 import { CommandSuggestion } from './types';
 
 export const suggestions: CommandSuggestion[] = [
@@ -7,7 +7,6 @@ export const suggestions: CommandSuggestion[] = [
   { command: 'skills', description: 'View technical expertise', icon: <Cpu className="w-4 h-4" style={{ color: 'var(--terminal-primary)' }} /> },
   { command: 'history', description: 'View career timeline', icon: <History className="w-4 h-4" style={{ color: 'var(--terminal-primary)' }} /> },
   { command: 'contact', description: 'Get contact information', icon: <Mail className="w-4 h-4" style={{ color: 'var(--terminal-primary)' }} /> },
-  { command: 'uptime', description: 'Session uptime', icon: <Clock className="w-4 h-4" style={{ color: 'var(--terminal-primary)' }} /> },
   { command: 'theme', description: 'Switch color theme', icon: <Palette className="w-4 h-4" style={{ color: 'var(--terminal-primary)' }} /> },
   { command: 'sound', description: 'Toggle terminal sounds', icon: <Volume2 className="w-4 h-4" style={{ color: 'var(--terminal-primary)' }} /> },
   { command: 'help', description: 'Show available commands', icon: <HelpCircle className="w-4 h-4" style={{ color: 'var(--terminal-primary)' }} /> },

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -11,6 +11,14 @@ export const hexToRgba = (hex: string, alpha: number): string => {
   return `rgba(${r}, ${g}, ${b}, ${alpha})`;
 };
 
+export const getCurrentTime = () =>
+  new Date().toLocaleTimeString('en-US', {
+    hour12: false,
+    hour: '2-digit',
+    minute: '2-digit',
+    second: '2-digit',
+  });
+
 export const formatUptime = (s: number): string => {
   const d = Math.floor(s / 86400);
   const h = Math.floor((s % 86400) / 3600);

--- a/src/index.css
+++ b/src/index.css
@@ -151,6 +151,14 @@ body {
   background: var(--terminal-primary);
 }
 
+/* Hidden scrollbar (scroll still works) */
+.scrollbar-hide {
+  scrollbar-width: none;
+}
+.scrollbar-hide::-webkit-scrollbar {
+  display: none;
+}
+
 /* CRT shutdown animation - vertical collapse to horizontal line, then shrink to dot */
 @keyframes crt-collapse {
   0% {

--- a/src/test/setup.ts
+++ b/src/test/setup.ts
@@ -77,12 +77,6 @@ window.requestAnimationFrame = (cb: FrameRequestCallback) =>
   setTimeout(() => cb(performance.now()), 0) as unknown as number;
 window.cancelAnimationFrame = (id: number) => clearTimeout(id);
 
-// navigator.vibrate mock
-Object.defineProperty(navigator, 'vibrate', {
-  writable: true,
-  value: vi.fn(),
-});
-
 // Default matchMedia predicate (all queries return false = mobile, no reduced motion)
 const defaultMatchMedia = (query: string) => ({
   matches: false,


### PR DESCRIPTION
## Summary

- **Show native keyboard** on mobile (`inputMode="search"`) instead of hiding it, matching user expectations from every major terminal app
- **Floating suggestion dropdown** with real-time prefix filtering, character highlighting, and tap-to-select — replaces the dedicated `[≡ Cmds]` button as the discovery mechanism
- **Simplified toolbar** from `[≡ Cmds] [↑] [↓] [⏎ Enter]` to `[↑] [↓]` — dual-purpose: navigate suggestions when dropdown is open, cycle command history when closed
- **Accessibility**: `role="log"` + `aria-live="polite"` on output, `role="listbox"`/`role="option"` on dropdown, `aria-expanded`/`aria-controls` on input, `aria-label` on toolbar buttons
- **Updated MOTD**: mobile shows "Type 'help' or tap the prompt to explore." (desktop unchanged)
- **Desktop completely unchanged** — all mobile changes gated behind `useIsMobile` hook

## Test Plan

- [x] 97 unit tests passing (14 test files)
- [x] TypeScript clean (`tsc --noEmit`)
- [x] Playwright manual testing (13-point mobile checklist, all passing)
- [ ] Manual test on physical iOS device (Safari)
- [ ] Manual test on physical Android device (Chrome)

🤖 Generated with [Claude Code](https://claude.com/claude-code)